### PR TITLE
Use Redis as a server side session store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,5 @@ DATABASE_URL=postgres://postgres@localhost:5432/homes-england-affordable-housing
 AUTH0_CLIENT_ID=
 AUTH0_CLIENT_SECRET=
 AUTH0_DOMAIN=
+
+REDIS_URL=redis://localhost:6379

--- a/.env.test
+++ b/.env.test
@@ -11,3 +11,5 @@ DATABASE_URL=postgres://postgres@localhost:5432/homes-england-affordable-housing
 AUTH0_CLIENT_ID=stand-in
 AUTH0_CLIENT_SECRET=stand-in
 AUTH0_DOMAIN=stand-in.local
+
+REDIS_URL=redis://localhost:6379

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - Add basic authentication with Auth0
 - Add Webpacker
 - Add GOV.UK frontend package and layout
+- Use Redis as a server side session store
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,10 @@ gem "jbuilder", "~> 2.5"
 gem "pg"
 gem "mini_racer"
 gem "puma", "~> 5.0"
+gem "redis", "~> 4.2", ">= 4.2.5"
+gem "redis-namespace"
+gem "redis-actionpack"
+gem "redis-store"
 gem "rollbar"
 gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
@@ -29,6 +33,7 @@ end
 
 group :test do
   gem "capybara", ">= 2.15"
+  gem "fakeredis", require: false
   gem "selenium-webdriver"
   gem "simplecov"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
       railties (>= 5.0.0)
     faker (2.15.1)
       i18n (>= 1.6, < 2)
+    fakeredis (0.8.0)
+      redis (~> 4.1)
     faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
@@ -204,6 +206,18 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.2.5)
+    redis-actionpack (5.2.0)
+      actionpack (>= 5, < 7)
+      redis-rack (>= 2.1.0, < 3)
+      redis-store (>= 1.1.0, < 2)
+    redis-namespace (1.8.0)
+      redis (>= 3.0.4)
+    redis-rack (2.1.3)
+      rack (>= 2.0.8, < 3)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.9.0)
+      redis (>= 4, < 5)
     regexp_parser (1.8.2)
     rexml (3.2.4)
     rollbar (3.0.1)
@@ -307,6 +321,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  fakeredis
   high_voltage
   jbuilder (~> 2.5)
   launchy
@@ -319,6 +334,10 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 6.0.0)
   rails_layout
+  redis (~> 4.2, >= 4.2.5)
+  redis-actionpack
+  redis-namespace
+  redis-store
   rollbar
   rspec-rails
   selenium-webdriver

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,15 @@
+redis_url = ENV.fetch("REDIS_URL", nil)
+redis_uri = URI(redis_url)
+redis_store_params = {
+  servers: {
+    host: redis_uri.host,
+    port: redis_uri.port,
+    db: 1,
+    namespace: "affordablehousing:session"
+  },
+  key: "_affordable_housing_session",
+  expire_after: 12.hours,
+  threadsafe: true
+}
+redis_store_params[:secure] = true if Rails.env.production?
+Rails.application.config.session_store :redis_store, **redis_store_params

--- a/doc/architecture/decisions/0014-use-server-side-session-store.md
+++ b/doc/architecture/decisions/0014-use-server-side-session-store.md
@@ -1,0 +1,33 @@
+# 14. use-a-server-side-session-store
+
+Date: 2020-12-08
+
+## Status
+
+Accepted
+
+## Context
+
+We have a CookieOverflow error that is prompting this work. It occurs when the
+service is storing more than 4KB of data within the cookie. A user signing in
+via Auth0 on production receives an error message.
+
+A current work-around is to delete your cookie and sign in again.
+
+Rails acknowledges [1] that the default cookie storage is fast but prone to this
+error.
+
+## Decision
+
+Use Redis as a server-side session store.
+
+## Consequences
+
+This gem is maintained by Redis and is a popular choice for session management.
+
+Redis will encrypt the session data at rest and serve the session back to the
+users browser for them to decrypt. Not having it unencrypted at rest would
+provide more defence in depth as Redis is already protected from public access
+at a network level.
+
+[1] https://guides.rubyonrails.org/security.html#session-storage

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require File.expand_path("../config/environment", __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
+require "fakeredis/rspec"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
On the staging service on Heroku, we were encountering ActionDispatch::Cookies::CookieOverflow
errors on attempting to log into Auth0. This is a known issue related to the
size of the cookie store in Rails (4kb).

In other dxw projects we have used Redis as a server side session store. The
Redis dyno is available on Heroku and simple to set up (it has been provisioned
on our staging Heroku before this PR was submitted).
