### PR TITLE
Reduce cookie size to avoid ActionDispatch::Cookies::CookieOverflow error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - Add basic authentication with Auth0
 - Add Webpacker
 - Add GOV.UK frontend package and layout
+- Reduce cookie size to avoid ActionDispatch::Cookies::CookieOverflow error
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -2,11 +2,17 @@ class AuthController < ApplicationController
   include LogoutHelper
 
   def callback
-    # This stores all the user information that came from Auth0
-    # and the IdP
-    session[:userinfo] = request.env.fetch("omniauth.auth")
+    # Store the uid, name and email address only for now
+    auth_response = request.env.fetch("omniauth.auth")
+    userinfo = {
+      "uid" => auth_response[:uid],
+      "info" => {
+        "name" => auth_response[:info][:name],
+        "email" => auth_response[:info][:email]
+      }
+    }
+    session[:userinfo] = userinfo
 
-    # Redirect to the URL you want after successful auth
     redirect_to dashboard_path
   end
 


### PR DESCRIPTION
The cookie returned from Auth0 is over 4kb, and therefore too large for the
built-in Rails cookie storage to handle.

Reduce the cookie size to just the parts we need for now. We can re-add some
of the Auth0 info if we need it later.

