### PR TITLE
Throw a Rollbar error when an unknown error occurs on Auth0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - Add Webpacker
 - Add GOV.UK frontend package and layout
 - Reduce cookie size to avoid ActionDispatch::Cookies::CookieOverflow error
+- Enable Rollbar and capture unknown errors from Auth0 using Rollbar
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -18,7 +18,10 @@ class AuthController < ApplicationController
 
   def failure
     message = request.params["message"]
-    @error_message = t("errors.auth0.#{message.to_sym}")
+    @error_message = I18n.t("errors.auth0.#{message.to_sym}", raise: true)
+  rescue I18n::MissingTranslationData
+    Rollbar.log(:info, "Unknown response from Auth0", message)
+    @error_message = I18n.t("errors.auth0.generic")
   end
 
   def logout

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,3 +35,4 @@ en:
   errors:
     auth0:
       invalid_credentials: Invalid credentials
+      generic: "An unknown error has occurred. Please try signing in again."

--- a/spec/features/users_can_log_in_spec.rb
+++ b/spec/features/users_can_log_in_spec.rb
@@ -26,4 +26,16 @@ feature "Log in" do
     expect(page).to_not have_content("You are logged in")
     expect(page).to have_content("Invalid credentials")
   end
+
+  scenario "An unknown error from Auth0 is logged to Rollbar" do
+    mock_unknown_error_failure
+    allow(Rollbar).to receive(:log)
+
+    visit root_path
+    click_button "Sign in"
+
+    expect(page).to_not have_content("You are logged in")
+    expect(page).to have_content(I18n.t("errors.auth0.generic"))
+    expect(Rollbar).to have_received(:log).with(:info, "Unknown response from Auth0", "unknown_error")
+  end
 end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -13,4 +13,8 @@ module AuthenticationHelpers
   def mock_invalid_credentials_failure
     OmniAuth.config.mock_auth[:auth0] = :invalid_credentials
   end
+
+  def mock_unknown_error_failure
+    OmniAuth.config.mock_auth[:auth0] = :unknown_error
+  end
 end


### PR DESCRIPTION
Outside of this commit, we have enabled Rollbar for this project.

To test the Rollbar integration is working correctly, and to capture unknown
errors from Auth0, add an exception thrown & logged by Rollbar when Auth0
cannot authenticate a user for an unknown reason.

