### PR TITLE
Create a Provider model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - Add GOV.UK frontend package and layout
 - Reduce cookie size to avoid ActionDispatch::Cookies::CookieOverflow error
 - Enable Rollbar and capture unknown errors from Auth0 using Rollbar
+- Create Providers model and seed database with known providers
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem "faker"
   gem "pry"
   gem "rspec-rails"
+  gem "shoulda-matchers", "~> 4.4", ">= 4.4.1"
   gem "standard"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,8 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (2.3.0)
+    shoulda-matchers (4.4.1)
+      activesupport (>= 4.2.0)
     simplecov (0.20.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -324,6 +326,7 @@ DEPENDENCIES
   rollbar
   rspec-rails
   selenium-webdriver
+  shoulda-matchers (~> 4.4, >= 4.4.1)
   simplecov
   spring
   spring-commands-rspec

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,0 +1,20 @@
+class Provider < ApplicationRecord
+  validates_presence_of :organisation_name, :registration_number, :designation
+  validates_presence_of :corporate_form, unless: -> { local_authority? }
+
+  enum corporate_form: {
+    company: "Company",
+    registered_society: "Registered Society",
+    charity: "Charity",
+    limited_liability_patnership: "LLP-Limited Liability Partnership",
+    charitable_incorporated_organisation: "CIO-Charitable Incorporated Organisation",
+    charitable_company: "Charitable Company",
+    community_interest_company: "CIC-Community Interest Company"
+  }
+
+  enum designation: {
+    non_profit: "Non-Profit",
+    profit: "Profit",
+    local_authority: "Local Authority"
+  }
+end

--- a/db/migrate/20201209165202_create_providers.rb
+++ b/db/migrate/20201209165202_create_providers.rb
@@ -1,0 +1,11 @@
+class CreateProviders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :providers, id: :uuid do |t|
+      t.string :organisation_name, index: true
+      t.string :registration_number
+      t.string :designation
+      t.string :corporate_form
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_12_09_165202) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "organisation_name"
+    t.string "registration_number"
+    t.string "designation"
+    t.string "corporate_form"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["organisation_name"], name: "index_providers_on_organisation_name"
+  end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,7 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+if Rails.env.development?
+  load File.join(Rails.root, "db", "seeds", "providers.rb")
+end

--- a/db/seeds/providers.rb
+++ b/db/seeds/providers.rb
@@ -8,5 +8,5 @@ providers.each do |provider|
     designation: Provider.designations.key(provider["Designation"]),
     corporate_form: Provider.corporate_forms.key(provider["Corporate Form"])
   }
-  Provider.find_or_create_by(registration_number: provider["Registration Number"]).update(provider_params)
+  Provider.find_or_create_by!(registration_number: provider.fetch("Registration Number")).update!(provider_params)
 end

--- a/db/seeds/providers.rb
+++ b/db/seeds/providers.rb
@@ -1,0 +1,12 @@
+require "yaml"
+
+providers = YAML.safe_load(File.read(File.join(Rails.root, "vendor", "data", "registered_providers_november_2020.yml")))
+providers.each do |provider|
+  provider_params = {
+    organisation_name: provider["Organisation Name"],
+    registration_number: provider["Registration Number"],
+    designation: Provider.designations.key(provider["Designation"]),
+    corporate_form: Provider.corporate_forms.key(provider["Corporate Form"])
+  }
+  Provider.find_or_create_by(registration_number: provider["Registration Number"]).update(provider_params)
+end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :provider do
+    organisation_name { Faker::Company.name }
+    registration_number { Faker::Alphanumeric }
+    designation { "non_profit" }
+    corporate_form { "charity" }
+
+    trait :local_authority do
+      designation { "local_authority" }
+      corporate_form { nil }
+    end
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Provider, type: :model do
+  describe "validations" do
+    it { should validate_presence_of(:organisation_name) }
+    it { should validate_presence_of(:registration_number) }
+    it { should validate_presence_of(:designation) }
+
+    context "when the designation is a Local Authority" do
+      subject { build(:provider, :local_authority) }
+      it { should_not validate_presence_of(:corporate_form) }
+    end
+
+    context "when the designation is not a Local Authority" do
+      subject { build(:provider) }
+      it { should validate_presence_of(:corporate_form) }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,3 +64,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/vendor/data/registered_providers_november_2020.yml
+++ b/vendor/data/registered_providers_november_2020.yml
@@ -1,0 +1,9829 @@
+---
+-
+  Organisation Name: 20-20 Housing Co-operative Limited
+  Registration Number: C3489
+  Registration Date: 20/07/1984
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: 3CHA Ltd
+  Registration Number: 4758
+  Registration Date: 22/03/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: 700 Club
+  Registration Number: 4811
+  Registration Date: 05/03/2015
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: A2Dominion Homes Limited
+  Registration Number: LH0391
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: A2Dominion Housing Group Limited
+  Registration Number: L4240
+  Registration Date: 23/11/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: A2Dominion Housing Options Limited
+  Registration Number: SL4293
+  Registration Date: 15/11/2000
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: A2Dominion South Limited
+  Registration Number: LH4149
+  Registration Date: 27/11/1997
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: AAIM Housing RP Limited
+  Registration Number: 5094
+  Registration Date: 02/04/2020
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Abbeyfield Braintree, Bocking and Felsted Society Limited
+  Registration Number: H0340
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Abbeyfield Bristol and Keynsham Society
+  Registration Number: H0315
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Abbeyfield Chester Society Limited
+  Registration Number: H0008
+  Registration Date: 25/03/1975
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Abbeyfield Grimsby, Cleethorpes and District Society Limited
+  Registration Number: H3577
+  Registration Date: 17/06/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Abbeyfield Hertfordshire Residential Care Society
+  Registration Number: H3610
+  Registration Date: 21/10/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Abbeyfield North Northumberland Extra Care Society Limited
+  Registration Number: H3403
+  Registration Date: 09/05/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Abbeyfield South Downs Limited
+  Registration Number: H0375
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Abbeyfield Southern Oaks
+  Registration Number: H1185
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Abbeyfield The Dales Limited
+  Registration Number: 5066
+  Registration Date: 08/02/2019
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Abbeyfield Wessex Society Limited
+  Registration Number: H2136
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Abbeyfield Wey Valley Society Limited
+  Registration Number: H3294
+  Registration Date: 07/06/1982
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Abeona Housing Co-operative Limited
+  Registration Number: C3455
+  Registration Date: 05/12/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Aberford Almshouses Trust
+  Registration Number: A0230
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Ability Housing Association
+  Registration Number: LH2174
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Abri Group Limited
+  Registration Number: L4172
+  Registration Date: 21/04/1998
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Accent Group Limited
+  Registration Number: L4511
+  Registration Date: 22/01/2008
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Accent Housing Limited
+  Registration Number: LH1722
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Access Homes Housing Association Limited
+  Registration Number: SL3605
+  Registration Date: 21/10/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: AccommodationYes Limited
+  Registration Number: 4810
+  Registration Date: 05/03/2015
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Accord Housing Association Limited
+  Registration Number: LH3902
+  Registration Date: 19/03/1990
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Acis Group Limited
+  Registration Number: L4229
+  Registration Date: 14/09/1999
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Action Housing and Support Limited
+  Registration Number: 4660
+  Registration Date: 02/06/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Adactus Housing Association Limited
+  Registration Number: LH0131
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Addiscombe Catholic Housing Association Limited
+  Registration Number: LH3197
+  Registration Date: 27/10/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Adler Housing
+  Registration Number: 4788
+  Registration Date: 18/03/2014
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Adullam Homes Housing Association Limited
+  Registration Number: LH1388
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Adur District Council
+  Registration Number: 45UB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Advance Housing and Support Limited
+  Registration Number: LH0280
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Affordable Housing Communities Limited
+  Registration Number: 4836
+  Registration Date: 09/11/2016
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Agamemnon Housing Association Limited
+  Registration Number: L0916
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Aged Merchant Seamen’s Homes
+  Registration Number: A1632
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Agudas Israel Housing Association Limited
+  Registration Number: LH3673
+  Registration Date: 21/07/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: AKSA Housing Association Limited
+  Registration Number: LH3917
+  Registration Date: 18/06/1990
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Albion Housing Co-operative Limited
+  Registration Number: C3719
+  Registration Date: 23/03/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Aldwyck Housing Group Limited
+  Registration Number: LH1682
+  Registration Date: 14/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Alice Coralie Glyn Homes
+  Registration Number: A0473
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Allandale Care Group Limited
+  Registration Number: H0357
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Alliance Housing Association (South Yorkshire) Limited
+  Registration Number: 4741
+  Registration Date: 01/11/2012
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Allnutt Mill Housing Co-operative Limited
+  Registration Number: C4108
+  Registration Date: 10/09/1996
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Allonby Almshouses
+  Registration Number: A3390
+  Registration Date: 14/03/1983
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Almshouse Charity
+  Registration Number: A2406
+  Registration Date: 13/06/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Almshouse Charity of Elizabeth Smith
+  Registration Number: A3714
+  Registration Date: 02/02/1987
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Almshouse Charity of Hannah Rawson
+  Registration Number: A3050
+  Registration Date: 15/09/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Almshouse Charity of Sir William Powell
+  Registration Number: A1157
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Almshouse of St John the Baptist & St John the Evangelist
+  Registration Number: A2569
+  Registration Date: 12/12/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Almshouses of Miss Anne Hopkins-Smith
+  Registration Number: A2987
+  Registration Date: 28/04/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Almshouses of William & Rebecca Pearce
+  Registration Number: A1073
+  Registration Date: 22/12/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Alpha (R.S.L.) Limited
+  Registration Number: L1033
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Alpha Housing Co-operative Limited
+  Registration Number: C3186
+  Registration Date: 08/06/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Alt Housing Co-operative Limited
+  Registration Number: C2438
+  Registration Date: 11/07/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Amicus Group Limited
+  Registration Number: L4216
+  Registration Date: 16/03/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: AmicusHorizon Limited
+  Registration Number: L4536
+  Registration Date: 12/10/2009
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Anchor Hanover Group
+  Registration Number: LH4095
+  Registration Date: 21/03/1996
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Anchor Property Holdings Limited
+  Registration Number: 4722
+  Registration Date: 04/07/2012
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Angiers Almshouse Charity
+  Registration Number: A2481
+  Registration Date: 12/09/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Apna Ghar Housing Association Limited
+  Registration Number: L4443
+  Registration Date: 24/05/2005
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Aragon Housing Association Limited
+  Registration Number: L4048
+  Registration Date: 20/09/1994
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Arawak Walton Housing Association Limited
+  Registration Number: L3713
+  Registration Date: 02/02/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Arches Housing Limited
+  Registration Number: LH0884
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Arcon Housing Association Limited
+  Registration Number: L0249
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Argyle Street Housing Co-operative Limited
+  Registration Number: C2303
+  Registration Date: 14/03/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Arhag Housing Association Limited
+  Registration Number: LH3811
+  Registration Date: 05/12/1988
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Arneway Housing Co-operative Limited
+  Registration Number: C3115
+  Registration Date: 08/12/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Arpeggio Properties Limited
+  Registration Number: 4726
+  Registration Date: 18/07/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Arun District Council
+  Registration Number: 45UC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Arundel Buildings Housing Co-operative Limited
+  Registration Number: C3379
+  Registration Date: 14/03/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Ascent Housing LLP
+  Registration Number: 4724
+  Registration Date: 12/07/2012
+  Designation: Profit
+  Corporate Form: LLP-Limited Liability Partnership
+-
+  Organisation Name: Asett Homes Ltd
+  Registration Number: 4856
+  Registration Date: 01/08/2017
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Ashbourne Almshouse Charity
+  Registration Number: A3257
+  Registration Date: 25/01/1982
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Ashfield District Council
+  Registration Number: 37UB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Ashford Borough Council
+  Registration Number: 29UB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Ashford Pavilion Housing Co-operative Limited
+  Registration Number: C4133
+  Registration Date: 21/05/1997
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Ashley Community & Housing Ltd
+  Registration Number: 4716
+  Registration Date: 01/06/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Ash-Shahada Housing Association Limited
+  Registration Number: C3843
+  Registration Date: 20/03/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Ashton Pioneer Homes Limited
+  Registration Number: L4199
+  Registration Date: 28/01/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Ashwell Housing Association Limited
+  Registration Number: L1517
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Aspire Housing Limited
+  Registration Number: L4238
+  Registration Date: 23/11/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Assured Living Housing Association Limited
+  Registration Number: 4731
+  Registration Date: 05/09/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Aster 3 Limited
+  Registration Number: 4872
+  Registration Date: 08/03/2018
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Aster Communities
+  Registration Number: 4691
+  Registration Date: 03/02/2012
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Aster Group Limited
+  Registration Number: L4393
+  Registration Date: 15/05/2003
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Aston Almshouse Charity
+  Registration Number: A3910
+  Registration Date: 19/03/1990
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Aston-Mansfield Charitable Trust
+  Registration Number: LH1396
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Ath-Gray Housing Co-operative Limited
+  Registration Number: C3299
+  Registration Date: 12/08/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Auckland Home Solutions Community Interest Company
+  Registration Number: 4690
+  Registration Date: 12/01/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Auxesia Homes Limited
+  Registration Number: 4765
+  Registration Date: 02/05/2013
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Aves Housing
+  Registration Number: 4664
+  Registration Date: 14/07/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Axiom Housing Association Limited
+  Registration Number: L0395
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Aylott Janes Almshouses
+  Registration Number: A0211
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: B3 Living Limited
+  Registration Number: L4455
+  Registration Date: 22/11/2005
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Babergh District Council
+  Registration Number: 42UB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Bahay Kubo Housing Association Limited
+  Registration Number: 4773
+  Registration Date: 12/07/2013
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Balkerne Gardens Trust Limited
+  Registration Number: LH1647
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Balsall Heath Housing Co-operative Limited
+  Registration Number: C2437
+  Registration Date: 11/07/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bangla Housing Association Limited
+  Registration Number: L4534
+  Registration Date: 20/11/2008
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Barnet Overseas Students Housing Association Ltd
+  Registration Number: L0394
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Barnsbury Housing Association Limited
+  Registration Number: L2518
+  Registration Date: 10/10/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Barnsley Metropolitan Borough Council
+  Registration Number: 00CC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Barnwood Housing Co-operative Limited
+  Registration Number: C3339
+  Registration Date: 13/09/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Barrow-in-Furness Borough Council
+  Registration Number: 16UC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Basildon District Council
+  Registration Number: 22UB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Bassetlaw District Council
+  Registration Number: 37UC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Bath & North East Somerset Council
+  Registration Number: 5110
+  Registration Date: 29/10/2020
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Bath Centre for Voluntary Service Homes
+  Registration Number: LH1028
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Battersea Tenants Co-operative Limited
+  Registration Number: C2198
+  Registration Date: 13/12/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Becket Trust Housing Association Limited
+  Registration Number: L0913
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bedfont Stoney Wall Housing Co-operative Limited
+  Registration Number: C3993
+  Registration Date: 22/09/1992
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bedford Citizens Housing Association Limited
+  Registration Number: LH1649
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Beech Housing Association Limited
+  Registration Number: SL3463
+  Registration Date: 23/01/1984
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Beer Community Land Trust Limited
+  Registration Number: 4807
+  Registration Date: 20/02/2015
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Belgrave Neighbourhood Co-op Housing Association Limited
+  Registration Number: C1810
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Belgrave Street Housing Co-operative Limited
+  Registration Number: C2873
+  Registration Date: 10/09/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Believe Housing Limited
+  Registration Number: 5071
+  Registration Date: 12/04/2019
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Benenden Almshouse Charities
+  Registration Number: A3448
+  Registration Date: 24/10/1983
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Ben-Motor & Allied Trades Benevolent Fund
+  Registration Number: LH3766
+  Registration Date: 01/02/1988
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Bernicia Group
+  Registration Number: 4868
+  Registration Date: 20/02/2018
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bespoke Supportive Tenancies Limited
+  Registration Number: 4718
+  Registration Date: 15/06/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Bethany Home Trust
+  Registration Number: A3334
+  Registration Date: 13/09/1982
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Bethel Housing Association Limited
+  Registration Number: L1216
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bexley Community Housing Association Limited
+  Registration Number: L0976
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bexley United Charities
+  Registration Number: A3035
+  Registration Date: 14/07/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Beyond Housing Limited
+  Registration Number: LH4401
+  Registration Date: 13/11/2003
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Billericay Community Housing Association Limited
+  Registration Number: L1397
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Birchfield House Co-operative Limited
+  Registration Number: C3127
+  Registration Date: 26/01/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Birkenhead Forum Housing Association Limited
+  Registration Number: L1299
+  Registration Date: 26/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Birmingham City Council
+  Registration Number: 00CN
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Birmingham Civic Housing Association Limited
+  Registration Number: L1389
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Birmingham Jewish Housing Association Limited
+  Registration Number: L2889
+  Registration Date: 13/09/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Birnbeck Housing Association Limited
+  Registration Number: L1511
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Black Country Housing Group Limited
+  Registration Number: L1668
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Blackburn YMCA
+  Registration Number: 4639
+  Registration Date: 14/01/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Blackpool Borough Council
+  Registration Number: 00EY
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Blenheim Housing Co-operative Limited
+  Registration Number: C4110
+  Registration Date: 10/09/1996
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Blue Pits Housing Action
+  Registration Number: 4719
+  Registration Date: 01/06/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Blue Square Residential Ltd
+  Registration Number: 4733
+  Registration Date: 06/09/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Blyth Cottages
+  Registration Number: A4196
+  Registration Date: 24/11/1998
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Bocking United Charities
+  Registration Number: A4038
+  Registration Date: 15/03/1994
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Bolsover District Council
+  Registration Number: 17UC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Bolton at Home Limited
+  Registration Number: 4568
+  Registration Date: 08/02/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bolton Council
+  Registration Number: 00BL
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Bomarsund Housing Co-operative Limited
+  Registration Number: C3745
+  Registration Date: 02/10/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bonham and Strathleven Tenants Co-operative Ltd
+  Registration Number: C2788
+  Registration Date: 12/03/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Boorman’s Almshouses
+  Registration Number: A4257
+  Registration Date: 03/02/2000
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Bordesley Green Housing Co-operative Limited
+  Registration Number: C3446
+  Registration Date: 24/10/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Boscombe Rotary and Inner Wheel Housing Association Limited
+  Registration Number: L1002
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Boughey Roddam Housing Association
+  Registration Number: L0528
+  Registration Date: 12/09/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bournemouth Churches Housing Association Limited
+  Registration Number: LH0155
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bournemouth Young Men’s Christian Association
+  Registration Number: H4246
+  Registration Date: 23/11/1999
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Bournemouth, Christchurch and Poole Council
+  Registration Number: 5069
+  Registration Date: 01/04/2019
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Bournville Village Trust
+  Registration Number: L0702
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Bournville Works Housing Society Limited
+  Registration Number: C1853
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bow Housing Society Limited
+  Registration Number: L0302
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: bpha Limited
+  Registration Number: LH3887
+  Registration Date: 29/01/1990
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bradford Cyrenians Limited
+  Registration Number: 4860
+  Registration Date: 05/09/2017
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Brandon Aged Persons Homes
+  Registration Number: A3768
+  Registration Date: 01/02/1988
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Brandon Poor’s Estate
+  Registration Number: A0644
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Brandrams Housing Co-operative Limited
+  Registration Number: C3185
+  Registration Date: 25/05/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Braughing Housing Association Limited
+  Registration Number: L1007
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Breedon Housing Co-operative Limited
+  Registration Number: C4379
+  Registration Date: 20/03/2003
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Brent Community Housing Limited
+  Registration Number: 4748
+  Registration Date: 15/01/2013
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Brentwood Borough Council
+  Registration Number: 22UD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Brentwood Housing Trust Limited
+  Registration Number: L1257
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bridge Care Limited
+  Registration Number: L3921
+  Registration Date: 23/07/1990
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Bridge-It Housing UK Team Ltd
+  Registration Number: 4736
+  Registration Date: 19/09/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Bridgwater YMCA
+  Registration Number: H4245
+  Registration Date: 23/11/1999
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Brighter Futures Housing Association Limited
+  Registration Number: H4315
+  Registration Date: 05/06/2001
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Brighton and Hove Almshouse Charity
+  Registration Number: A1614
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Brighton and Hove City Council
+  Registration Number: 00ML
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Brighton and Hove Jewish Housing Association Limited
+  Registration Number: L0449
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Brighton Buildings Housing Co-operative Limited
+  Registration Number: C3638
+  Registration Date: 17/03/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Brighton Housing Trust
+  Registration Number: H1696
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Brighton Lions Housing Society Limited
+  Registration Number: L0690
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Brighton YMCA
+  Registration Number: H3835
+  Registration Date: 22/02/1989
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Bristol and Anchor Almshouse Charity
+  Registration Number: A4256
+  Registration Date: 03/02/2000
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Bristol City Council
+  Registration Number: 00HB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Bristol CLT Limited
+  Registration Number: 4801
+  Registration Date: 15/12/2014
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bristowe (Fair Rent) Housing Association Limited
+  Registration Number: L1990
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Brixton Housing Co-operative Limited
+  Registration Number: C2576
+  Registration Date: 09/07/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Broadacres Housing Association Limited
+  Registration Number: LH4014
+  Registration Date: 20/04/1993
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Broadening Choices for Older People
+  Registration Number: L4218
+  Registration Date: 16/03/1999
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Broadland Housing Association Limited
+  Registration Number: L0026
+  Registration Date: 25/03/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Broadway Living RP Limited
+  Registration Number: 5105
+  Registration Date: 01/10/2020
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Brockley Tenants Co-operative Limited
+  Registration Number: C2430
+  Registration Date: 11/07/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bromford Home Ownership Limited
+  Registration Number: L4450
+  Registration Date: 04/10/2005
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bromford Housing Association Limited
+  Registration Number: 4819
+  Registration Date: 14/04/2015
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bromford Housing Group Limited
+  Registration Number: L4449
+  Registration Date: 04/10/2005
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bromley and Sheppard’s Colleges Charity
+  Registration Number: A0352
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Bromsgrove District Housing Trust Limited
+  Registration Number: LH4415
+  Registration Date: 23/03/2004
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Bromsgrove United Charities
+  Registration Number: A1067
+  Registration Date: 22/12/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Brownlow Hill Housing Co-operative Limited
+  Registration Number: C3718
+  Registration Date: 13/03/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Broxtowe Borough Council
+  Registration Number: 37UD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Brunelcare
+  Registration Number: LH0269
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Brunts Charity
+  Registration Number: A2722
+  Registration Date: 10/08/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Buckinghamshire Housing Association Limited
+  Registration Number: L2007
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Bucklehaven Charity
+  Registration Number: A0752
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Bury Metropolitan Borough Council
+  Registration Number: 00BM
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Butlin and Elborow Housing Trust
+  Registration Number: 4881
+  Registration Date: 24/05/2018
+  Designation: Non-Profit
+  Corporate Form: CIO-Charitable Incorporated Organisation
+-
+  Organisation Name: Butterfield Homes (Cottingley)
+  Registration Number: A3825
+  Registration Date: 05/12/1988
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Butterfield Homes (Wilsden)
+  Registration Number: A3623
+  Registration Date: 02/12/1985
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Byker Community Trust Limited
+  Registration Number: 4714
+  Registration Date: 03/05/2012
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: C of E Soldiers, Sailors & Airmens H.A Ltd
+  Registration Number: L0104
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Calder Valley Community Land Trust Limited
+  Registration Number: 5050
+  Registration Date: 07/06/2018
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Calico Homes Limited
+  Registration Number: L4254
+  Registration Date: 03/02/2000
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Calverton Almshouses Charity
+  Registration Number: A0811
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Camberwell Housing Society
+  Registration Number: L1976
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cambridge City Council
+  Registration Number: 12UB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Canning Housing Co-operative Limited
+  Registration Number: C1981
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cannock Chase District Council
+  Registration Number: 41UB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Canterbury City Council
+  Registration Number: 29UC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Care Housing Association Limited
+  Registration Number: 4672
+  Registration Date: 14/09/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Caritas Anchor House
+  Registration Number: 4841
+  Registration Date: 07/03/2017
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Castle Housing Limited
+  Registration Number: 4709
+  Registration Date: 19/04/2012
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Castle Point Borough Council
+  Registration Number: 22UE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Castles & Coasts Housing Association Limited
+  Registration Number: 4858
+  Registration Date: 04/08/2017
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Catalyst Housing Limited
+  Registration Number: L0699
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cathedral Mansions Housing Co-operative Limited
+  Registration Number: C3856
+  Registration Date: 15/05/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cedarmore Housing Association Limited
+  Registration Number: L0047
+  Registration Date: 16/04/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Central and Cecil Housing Trust
+  Registration Number: H1528
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Central Bedfordshire Council
+  Registration Number: 00KC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Centrepoint
+  Registration Number: H1869
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Changing Lives Housing Trust
+  Registration Number: 4641
+  Registration Date: 08/02/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Charity of Alice Dale
+  Registration Number: A2820
+  Registration Date: 04/06/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Charity of Annie Kew
+  Registration Number: A2891
+  Registration Date: 22/10/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Charity of Elizabeth Owen, Llanfair
+  Registration Number: A2706
+  Registration Date: 28/06/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Charity Of Elizabeth Wadsworth
+  Registration Number: A3681
+  Registration Date: 21/07/1986
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Charity of Emma Rice & W.E.J. Knight
+  Registration Number: A3751
+  Registration Date: 19/10/1987
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Charity of George Jones
+  Registration Number: A0364
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Charity of Jonathan & Rebecca Edwards
+  Registration Number: A2710
+  Registration Date: 28/06/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Charity of Julia Spicer for Almshouses
+  Registration Number: A2395
+  Registration Date: 13/06/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Charity of Marjorie Hurst
+  Registration Number: A4057
+  Registration Date: 13/12/1994
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Charity of Mrs Catherine Walker
+  Registration Number: A4430
+  Registration Date: 09/11/2004
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Charity of Sarah Jane Wood & Mary A Garnett
+  Registration Number: A3540
+  Registration Date: 03/12/1984
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Charity of William Brereton for the Poor
+  Registration Number: A0831
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Charles Edward Sugden’s Almshouses
+  Registration Number: A3990
+  Registration Date: 21/07/1992
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Charlton Triangle Homes Limited
+  Registration Number: L4212
+  Registration Date: 16/03/1999
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Charnwood Borough Council
+  Registration Number: 31UC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Chartford Housing Limited
+  Registration Number: 4821
+  Registration Date: 01/10/2015
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Chelmer Housing Partnership Limited
+  Registration Number: L4331
+  Registration Date: 13/02/2002
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Chelmsford City Council
+  Registration Number: 5096
+  Registration Date: 06/07/2020
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Cheltenham Borough Council
+  Registration Number: 23UB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Cheltenham Borough Homes Limited
+  Registration Number: 4572
+  Registration Date: 03/06/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Cheltenham Young Men’s Christian Association
+  Registration Number: H4270
+  Registration Date: 21/03/2000
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Cherry Hinton Almshouse Charity
+  Registration Number: A2604
+  Registration Date: 13/02/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Cherryfield Housing Co-operative Limited
+  Registration Number: C3608
+  Registration Date: 21/10/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cherwell District Council
+  Registration Number: 38UB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Cheshire Peaks & Plains Housing Trust Limited
+  Registration Number: L4472
+  Registration Date: 11/07/2006
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cheshire West and Chester Council
+  Registration Number: 00EW
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Chesterfield Borough Council
+  Registration Number: 17UD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Chesterfield Churches Housing Association Limited
+  Registration Number: LH3942
+  Registration Date: 12/03/1991
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Chichester Greyfriars Housing Association Limited
+  Registration Number: L1306
+  Registration Date: 26/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Chippenham Housing Co-operative Limited
+  Registration Number: C3497
+  Registration Date: 23/07/1984
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Chisel Limited
+  Registration Number: L3642
+  Registration Date: 17/03/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Chislehurst and Sidcup Housing Association
+  Registration Number: L1693
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Chiswick Parochial Charities
+  Registration Number: A0821
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Choices Housing Association Limited
+  Registration Number: L4178
+  Registration Date: 09/06/1998
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Chorley Community Housing Limited
+  Registration Number: L4487
+  Registration Date: 20/03/2007
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Chorley Council
+  Registration Number: 30UE
+  Registration Date: 02/09/2011
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Chorus Homes Group Limited
+  Registration Number: L4398
+  Registration Date: 11/09/2003
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Chorus Homes Limited
+  Registration Number: LH4253
+  Registration Date: 03/02/2000
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Christian Action (Enfield) Housing Association Limited
+  Registration Number: LH0676
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Chrysalis Supported Association Limited
+  Registration Number: 4751
+  Registration Date: 07/02/2013
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Chubb, Whetstone and Napper’s Almshouses
+  Registration Number: A2868
+  Registration Date: 10/09/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Church Almshouses Charity
+  Registration Number: A2070
+  Registration Date: 30/07/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Churches Housing Assocation of Dudley and District Limited
+  Registration Number: LH2916
+  Registration Date: 22/10/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cirencester Housing Limited
+  Registration Number: L1444
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Citizen Housing Group Limited
+  Registration Number: 5075
+  Registration Date: 09/09/2019
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: City of Bradford Metropolitan District Council
+  Registration Number: 00CX
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: City of Exeter YMCA
+  Registration Number: H3905
+  Registration Date: 12/04/1990
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: City of Lincoln Council
+  Registration Number: 32UD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: City Of Liverpool YMCA (Incorporated)
+  Registration Number: H1720
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: City of London Corporation
+  Registration Number: 00AA
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: City of Wells Almshouses
+  Registration Number: A4055
+  Registration Date: 01/11/1994
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: City of Westminster Council
+  Registration Number: 00BK
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: City of York Council
+  Registration Number: 00FF
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: City YMCA, London
+  Registration Number: H4099
+  Registration Date: 28/05/1996
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Clarion Housing Association Limited
+  Registration Number: 4865
+  Registration Date: 09/01/2018
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Clarion Housing Group Limited
+  Registration Number: LH4087
+  Registration Date: 25/01/1996
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Claverdon Benefice Housing Association Limited
+  Registration Number: L0156
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Clifton Parish Houses
+  Registration Number: A1056
+  Registration Date: 22/12/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Clissold Housing Co-operative Limited
+  Registration Number: C3041
+  Registration Date: 14/07/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Coastline Housing Limited
+  Registration Number: LH4165
+  Registration Date: 17/03/1998
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Cobalt Housing Limited
+  Registration Number: L4361
+  Registration Date: 16/01/2003
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Coin Street Secondary Housing Co-operative Limited
+  Registration Number: C3729
+  Registration Date: 11/05/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Colchester Borough Council
+  Registration Number: 22UG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Collins Memorial Trust
+  Registration Number: A2482
+  Registration Date: 12/09/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Colne Housing Society Limited
+  Registration Number: LH1651
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Colonel Slater Homes
+  Registration Number: A3325
+  Registration Date: 13/09/1982
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Colton’s Hospital
+  Registration Number: A3033
+  Registration Date: 14/07/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Commonplace Housing Co-operative Limited
+  Registration Number: C2457
+  Registration Date: 21/11/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Community Gateway Association Limited
+  Registration Number: L4457
+  Registration Date: 24/11/2005
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Concept Housing Association CIC
+  Registration Number: 4780
+  Registration Date: 03/10/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Condlyffe Charity
+  Registration Number: A2991
+  Registration Date: 28/04/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Connect Housing Association Limited
+  Registration Number: L2285
+  Registration Date: 14/02/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Connexus Housing Limited
+  Registration Number: L4494
+  Registration Date: 24/07/2007
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Connexus Housing One Limited
+  Registration Number: LH3943
+  Registration Date: 12/03/1991
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Connexus Housing Three Limited
+  Registration Number: L4493
+  Registration Date: 24/07/2007
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Connexus Housing Two Limited
+  Registration Number: LH4353
+  Registration Date: 14/11/2002
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Contour Homes Limited
+  Registration Number: L3261
+  Registration Date: 01/04/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Convent Co-operative Limited
+  Registration Number: C3554
+  Registration Date: 11/03/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cooke Almshouse Charity
+  Registration Number: A4153
+  Registration Date: 27/11/1997
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Cooke’s Almshouse Charity
+  Registration Number: A3647
+  Registration Date: 17/03/1986
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Co-op Homes (South) Limited
+  Registration Number: C3675
+  Registration Date: 21/07/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Co-op Schemes For The Elderly Ltd
+  Registration Number: C3756
+  Registration Date: 07/12/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cooper and Adkinson Almshouse Charity
+  Registration Number: A3783
+  Registration Date: 09/05/1988
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Co-operative Development Society Limited
+  Registration Number: LH0170
+  Registration Date: 23/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Copland Almshouse Charity
+  Registration Number: A2946
+  Registration Date: 28/01/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Corby Borough Council
+  Registration Number: 34UB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Corn and Yates Streets Housing Co-operative Ltd
+  Registration Number: C2417
+  Registration Date: 13/06/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cornerstone Housing Limited
+  Registration Number: L0147
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cornfield Housing Society Limited
+  Registration Number: C0580
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cornwall CLT Limited
+  Registration Number: 5088
+  Registration Date: 05/03/2020
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cornwall Council
+  Registration Number: 00HE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Cornwall Housing Limited
+  Registration Number: 4570
+  Registration Date: 02/12/2010
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Cornwall Rural Housing Association Limited
+  Registration Number: L3613
+  Registration Date: 02/12/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Corton House Limited
+  Registration Number: LH1960
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cossington Housing Co-operative Limited
+  Registration Number: C2787
+  Registration Date: 12/03/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cotman Housing Association Limited
+  Registration Number: L0284
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cottsway 2
+  Registration Number: 5073
+  Registration Date: 22/07/2019
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cottsway Housing Association Limited
+  Registration Number: L4312
+  Registration Date: 22/03/2001
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Council of the Isles of Scilly
+  Registration Number: 00HF
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Countess of Derby’s Almshouse
+  Registration Number: A1071
+  Registration Date: 22/12/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: County Durham Housing Group Limited
+  Registration Number: 4805
+  Registration Date: 05/02/2015
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Coventry & Warwickshire YMCA
+  Registration Number: H4433
+  Registration Date: 18/01/2005
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Coventry Church (Municipal) Charities
+  Registration Number: A0581
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Craven District Council
+  Registration Number: 36UB
+  Registration Date: 15/03/2016
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Crawley Borough Council
+  Registration Number: 45UE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Craymill Housing Co-operative Limited
+  Registration Number: C3125
+  Registration Date: 26/01/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Creative Support Limited
+  Registration Number: 4689
+  Registration Date: 12/01/2012
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Crewe YMCA
+  Registration Number: H4058
+  Registration Date: 13/12/1994
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Croft Housing Association Limited
+  Registration Number: 4715
+  Registration Date: 28/05/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Cromwood Housing Ltd
+  Registration Number: 4764
+  Registration Date: 23/04/2013
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Crosby Housing Association Limited
+  Registration Number: L1719
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cross Keys Homes Limited
+  Registration Number: LH4428
+  Registration Date: 28/09/2004
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cross Lances Housing Co-operative Limited
+  Registration Number: C3335
+  Registration Date: 13/09/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Croydon Churches Housing Association Limited
+  Registration Number: LH0495
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Crystal Palace Housing Association Limited
+  Registration Number: SL3118
+  Registration Date: 26/01/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Curo Group (Albion) Limited
+  Registration Number: LH4336
+  Registration Date: 20/03/2002
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Curo Places Limited
+  Registration Number: LH4209
+  Registration Date: 16/03/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: CWL Housing
+  Registration Number: L1530
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Cyron Housing Co-operative Limited
+  Registration Number: C2695
+  Registration Date: 28/06/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Dacorum Borough Council
+  Registration Number: 26UC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Dale & Valley Homes Limited
+  Registration Number: 4575
+  Registration Date: 05/02/2015
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Dame Bertha Lopes Almshouses
+  Registration Number: A4408
+  Registration Date: 20/01/2004
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Danby Almshouse Charity
+  Registration Number: A3010
+  Registration Date: 09/06/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Darent Housing Co-operative Limited
+  Registration Number: C3300
+  Registration Date: 12/07/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Darlington Borough Council
+  Registration Number: 00EH
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Darlington Housing Association Limited
+  Registration Number: LH2346
+  Registration Date: 18/04/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Dartford Almshouse Charity
+  Registration Number: A2448
+  Registration Date: 11/07/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Dartford Borough Council
+  Registration Number: 29UD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Daventry District Council
+  Registration Number: 5076
+  Registration Date: 17/09/2019
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: David Henry Waring Home
+  Registration Number: L2023
+  Registration Date: 12/07/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Dawley Housing Co-operative Limited
+  Registration Number: C3890
+  Registration Date: 29/01/1990
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Dawson Housing Ltd
+  Registration Number: 5058
+  Registration Date: 06/09/2018
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Day’s & Atkinson’s Almshouse Charity
+  Registration Number: A4271
+  Registration Date: 21/03/2000
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Delce Manor Housing Co-operative Limited
+  Registration Number: C4100
+  Registration Date: 28/05/1996
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Dennetts Housing Co-operative Limited
+  Registration Number: C3691
+  Registration Date: 08/09/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Depaul Housing Services
+  Registration Number: 4792
+  Registration Date: 05/06/2014
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Deptford Housing Co-operative Limited
+  Registration Number: C2300
+  Registration Date: 14/03/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Derby City Council
+  Registration Number: 00FK
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Derby Homes Limited
+  Registration Number: 4576
+  Registration Date: 11/04/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Derbyshire Dales District Council
+  Registration Number: 5100
+  Registration Date: 13/08/2020
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Derventio Housing Trust CIC
+  Registration Number: 4677
+  Registration Date: 17/10/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Derwent Community Housing Association Limited
+  Registration Number: 4790
+  Registration Date: 14/05/2014
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Derwent Housing Association Limited
+  Registration Number: L0715
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Dholak Partnership Homes Limited
+  Registration Number: 5081
+  Registration Date: 05/12/2019
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Dimensions (UK) Limited
+  Registration Number: 4648
+  Registration Date: 14/03/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Dingle Residents Co-operative Limited
+  Registration Number: C3226
+  Registration Date: 26/10/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: District Homes CIC
+  Registration Number: 4787
+  Registration Date: 06/03/2014
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Dolphin Living Limited
+  Registration Number: 4813
+  Registration Date: 05/03/2015
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Doncaster Metropolitan Borough Council
+  Registration Number: 00CE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Doncaster Young Men’s Christian Association
+  Registration Number: H3639
+  Registration Date: 17/03/1986
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Dorking Charity
+  Registration Number: A2255
+  Registration Date: 17/01/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Dormer’s Hospital Charity
+  Registration Number: A2917
+  Registration Date: 03/12/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Dorset Council
+  Registration Number: 5099
+  Registration Date: 07/08/2020
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Dovepark Properties Limited
+  Registration Number: 4852
+  Registration Date: 13/07/2017
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Dover District Council
+  Registration Number: 29UE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Drayton Parochial Charities
+  Registration Number: A2367
+  Registration Date: 18/04/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Drum Housing Association Limited
+  Registration Number: LH4090
+  Registration Date: 25/01/1996
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Dudley Metropolitan Borough Council
+  Registration Number: 00CR
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Dunk’s Almshouse Charity
+  Registration Number: A4157
+  Registration Date: 20/01/1998
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Durham Action on Single Housing Limited
+  Registration Number: 5087
+  Registration Date: 09/03/2020
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Durham Aged Mineworkers’ Homes Association
+  Registration Number: A3213
+  Registration Date: 14/09/1981
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Durham City Homes Limited
+  Registration Number: 4806
+  Registration Date: 05/02/2015
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Durham County Council
+  Registration Number: 00EJ
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: E W King Memorial Homes
+  Registration Number: A2721
+  Registration Date: 10/08/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Earle’s Retreat
+  Registration Number: A3538
+  Registration Date: 03/12/1984
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Earsdon, Newburn and Shilbottle Almshouse Charity
+  Registration Number: A3485
+  Registration Date: 30/04/1984
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: East Boro Housing Trust Limited
+  Registration Number: L0519
+  Registration Date: 12/09/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: East Devon District Council
+  Registration Number: 18UB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: East Durham Homes Limited
+  Registration Number: 4578
+  Registration Date: 05/02/2015
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: East End Homes Limited
+  Registration Number: L4434
+  Registration Date: 18/02/2005
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: East Hertfordshire District Council
+  Registration Number: 26UD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: East Midlands Housing Group Limited
+  Registration Number: L4530
+  Registration Date: 14/10/2008
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: East Riding Of Yorkshire Council
+  Registration Number: 00FB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: East Suffolk Council
+  Registration Number: 5070
+  Registration Date: 01/04/2019
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Eastbourne Borough Council
+  Registration Number: 21UC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Eastlight Community Homes Limited
+  Registration Number: L4499
+  Registration Date: 15/10/2007
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Easy Housing Association Ltd
+  Registration Number: 4670
+  Registration Date: 04/08/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Ebony Sistren Housing Association Limited
+  Registration Number: LH3882
+  Registration Date: 04/12/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Ecco Housing Association Limited
+  Registration Number: L0451
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Eden Housing Association Limited
+  Registration Number: L4140
+  Registration Date: 09/09/1997
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Edward Henry House Co-operative Limited
+  Registration Number: C2745
+  Registration Date: 25/10/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Edward Mayes Trust
+  Registration Number: 5072
+  Registration Date: 12/04/2019
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Ekarro Housing Co-operative Limited
+  Registration Number: C3098
+  Registration Date: 27/10/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Ekaya Housing Association Limited
+  Registration Number: LH3940
+  Registration Date: 12/03/1991
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Eldon Housing Association Limited
+  Registration Number: L3262
+  Registration Date: 01/03/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Eldonian Community Based Housing Association Ltd
+  Registration Number: C3609
+  Registration Date: 21/10/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Eleanor Palmer Trust
+  Registration Number: A1168
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Elim Housing Association Limited
+  Registration Number: LH0977
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Elizabeth Dowell’s Trust
+  Registration Number: A2786
+  Registration Date: 12/03/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Elizabeth Huggins Cottages Charity
+  Registration Number: A3205
+  Registration Date: 13/07/1981
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Elles Housing Co-operative Limited
+  Registration Number: C3129
+  Registration Date: 26/01/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Elm Trees Retirement Living Limited
+  Registration Number: H0374
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: EMH Housing and Regeneration Limited
+  Registration Number: 4775
+  Registration Date: 16/09/2013
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Emily Bentley Homes
+  Registration Number: A3838
+  Registration Date: 30/01/1989
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Emily Brydges Willyams Memorial Houses
+  Registration Number: A3386
+  Registration Date: 14/03/1983
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Empower Housing Association Limited
+  Registration Number: 4663
+  Registration Date: 14/07/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Empowering People Inspiring Communities Limited
+  Registration Number: L4167
+  Registration Date: 17/03/1998
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Encircle Housing
+  Registration Number: 4784
+  Registration Date: 10/01/2014
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: English Rural Housing Association Limited
+  Registration Number: L4004
+  Registration Date: 15/12/1992
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Enham Trust
+  Registration Number: LH0526
+  Registration Date: 12/09/1975
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Epping Forest District Council
+  Registration Number: 22UH
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Epsom and Ewell Housing Association Limited
+  Registration Number: L0038
+  Registration Date: 16/04/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Equity Housing Group Limited
+  Registration Number: L1229
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Estuary Housing Association Limited
+  Registration Number: L3535
+  Registration Date: 03/12/1984
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Eustace Hook and Drummond Memorial Almshouses
+  Registration Number: A3245
+  Registration Date: 07/12/1981
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Eventide & Watts Charity
+  Registration Number: L2650
+  Registration Date: 10/04/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Everbrook Housing Co-operative Limited
+  Registration Number: C3023
+  Registration Date: 09/06/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Evolve Housing + Support
+  Registration Number: H4400
+  Registration Date: 11/09/2003
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Ewart Road Housing Co-operative Limited
+  Registration Number: C3284
+  Registration Date: 07/06/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Excel Housing Solutions
+  Registration Number: 4794
+  Registration Date: 03/07/2014
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Exeter City Council
+  Registration Number: 18UC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Exeter Homes Trust
+  Registration Number: A1921
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Expectations (UK)
+  Registration Number: 4774
+  Registration Date: 16/09/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Fairfield Moravian Housing Association Limited
+  Registration Number: L3790
+  Registration Date: 18/07/1988
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Fairhazel Co-operative Limited
+  Registration Number: C0447
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Fairoak Housing Association
+  Registration Number: L4535
+  Registration Date: 08/01/2009
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Fairplace Homes Ltd
+  Registration Number: 4797
+  Registration Date: 02/10/2014
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Falcon Housing Association C.I.C
+  Registration Number: 4771
+  Registration Date: 09/07/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Falcon Rural Housing Limited
+  Registration Number: L3629
+  Registration Date: 27/01/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Falconar Street Housing Co-operative Limited
+  Registration Number: C2747
+  Registration Date: 25/10/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Family Housing Association (Birkenhead and Wirral) Limited
+  Registration Number: L1236
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Family Housing Association (Birmingham) Limited
+  Registration Number: LH0713
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Fareham Borough Council
+  Registration Number: 24UE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Farmer and Lemmoin-Cannon Charity
+  Registration Number: A3761
+  Registration Date: 07/12/1987
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Feldon Housing Limited
+  Registration Number: 5049
+  Registration Date: 07/06/2018
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Fence Trust
+  Registration Number: A3989
+  Registration Date: 21/07/1992
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Finsbury Park Housing Co-operative Limited
+  Registration Number: C2949
+  Registration Date: 28/01/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: First Affordable Limited
+  Registration Number: 4832
+  Registration Date: 06/10/2016
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: First Choice Homes Oldham Limited
+  Registration Number: 4582
+  Registration Date: 12/01/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: First Garden Cities Homes Limited
+  Registration Number: 5090
+  Registration Date: 11/03/2020
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: First Priority Housing Association Limited
+  Registration Number: 4702
+  Registration Date: 29/03/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: First Wave Housing Limited
+  Registration Number: 4569
+  Registration Date: 01/04/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Fitzgerald Charity
+  Registration Number: A2363
+  Registration Date: 18/04/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Five Villages Home Association Limited
+  Registration Number: L2195
+  Registration Date: 13/12/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Flagship Housing Group Limited
+  Registration Number: 4651
+  Registration Date: 01/04/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Folkestone and Hythe District Council
+  Registration Number: 29UL
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Ford Street and Maynard Almshouse Charity
+  Registration Number: A3536
+  Registration Date: 03/12/1984
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Forest Housing Association Limited
+  Registration Number: L0087
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: ForHousing Limited
+  Registration Number: L4528
+  Registration Date: 15/07/2008
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Fotherby Almshouse Charities
+  Registration Number: A4023
+  Registration Date: 14/12/1993
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Foundation
+  Registration Number: 4688
+  Registration Date: 12/01/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Fountain Housing Association Limited
+  Registration Number: LH0910
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Framework Housing Association
+  Registration Number: LH4184
+  Registration Date: 10/09/1998
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Frank Crossley’s Almshouses
+  Registration Number: A0656
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Franklands Village Housing Association Limited
+  Registration Number: L1680
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Franklyn Housing Co-operative Limited
+  Registration Number: C3991
+  Registration Date: 22/09/1992
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Freebridge Community Housing Limited
+  Registration Number: L4463
+  Registration Date: 14/03/2006
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Freeston and Sagar’s Almshouses
+  Registration Number: A2709
+  Registration Date: 28/06/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: French Weir Affordable Homes LLP
+  Registration Number: 4739
+  Registration Date: 26/10/2012
+  Designation: Profit
+  Corporate Form: LLP-Limited Liability Partnership
+-
+  Organisation Name: Friendship Care and Housing Limited
+  Registration Number: 4654
+  Registration Date: 28/04/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Frontis Homes Limited
+  Registration Number: L4204
+  Registration Date: 25/02/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Funding Affordable Homes Housing Association Limited
+  Registration Number: 4829
+  Registration Date: 08/08/2016
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Futures Homescape Limited
+  Registration Number: L4372
+  Registration Date: 13/02/2003
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Futures Homeway Limited
+  Registration Number: L4498
+  Registration Date: 15/10/2007
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Futures Housing Group Limited
+  Registration Number: L4502
+  Registration Date: 15/10/2007
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Gateshead Metropolitan Borough Council
+  Registration Number: 00CH
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Gateway Housing Association Limited
+  Registration Number: L0517
+  Registration Date: 12/09/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Gemini Housing Co-operative Limited
+  Registration Number: C3906
+  Registration Date: 19/03/1990
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Gentoo Group Limited
+  Registration Number: L4313
+  Registration Date: 22/03/2001
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: George Green’s Almshouses
+  Registration Number: A3038
+  Registration Date: 14/07/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: George Newton Housing Trust
+  Registration Number: A4080
+  Registration Date: 25/09/1995
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: German Lutheran Housing Association Limited
+  Registration Number: L3598
+  Registration Date: 16/09/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Giffard Park Housing Co-operative Limited
+  Registration Number: C3378
+  Registration Date: 14/03/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Glebe Housing Association Limited
+  Registration Number: L0664
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Glenkerry Co-operative Housing Association Limited
+  Registration Number: C2730
+  Registration Date: 16/08/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Gloucester City Council
+  Registration Number: 23UE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Gloucester City Homes Limited
+  Registration Number: 4584
+  Registration Date: 05/02/2015
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Gloucestershire Rural Housing Association Limited
+  Registration Number: L3626
+  Registration Date: 27/01/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Glover’s Trust Endowed Fund
+  Registration Number: A3267
+  Registration Date: 01/03/1982
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Golden Hill Housing Co-operative Limited
+  Registration Number: C4135
+  Registration Date: 21/05/1997
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Golden Lane Housing Ltd
+  Registration Number: 4803
+  Registration Date: 15/01/2015
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Golding Homes Limited
+  Registration Number: LH4402
+  Registration Date: 13/11/2003
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Goodwin Development Trust
+  Registration Number: 4799
+  Registration Date: 19/11/2014
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Gosport Borough Council
+  Registration Number: 24UF
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Grafton Crescent Housing Co-operative Limited
+  Registration Number: C3227
+  Registration Date: 26/10/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Grainger Trust Limited
+  Registration Number: 4743
+  Registration Date: 07/11/2012
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Granby House (Youlgrave and District) Society Ltd
+  Registration Number: H3862
+  Registration Date: 15/05/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Grand Feoffment Charity
+  Registration Number: A1752
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Grand Union Housing Co-operative Limited
+  Registration Number: C2683
+  Registration Date: 24/01/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Grand Union Housing Group Limited
+  Registration Number: 5060
+  Registration Date: 16/10/2018
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Grantham’s Almshouses
+  Registration Number: A3583
+  Registration Date: 17/06/1985
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Gravesend Churches Housing Association Limited
+  Registration Number: LH0870
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Gravesham Borough Council
+  Registration Number: 29UG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Great Hospital
+  Registration Number: A0846
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Great Places Housing Association
+  Registration Number: L1230
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Great Places Housing Group Limited
+  Registration Number: L4465
+  Registration Date: 21/03/2006
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Great Wall Society Limited
+  Registration Number: H3762
+  Registration Date: 07/12/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Great Yarmouth Borough Council
+  Registration Number: 33UD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Greatwell Homes Limited
+  Registration Number: L4509
+  Registration Date: 13/11/2007
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Green Dragon Lane Housing Co-operative Limited
+  Registration Number: C2682
+  Registration Date: 22/05/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Green Park Property Management Limited
+  Registration Number: 4710
+  Registration Date: 19/04/2012
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Greenoak Housing Association Limited
+  Registration Number: L1393
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: GreenSquare Community Housing
+  Registration Number: 4732
+  Registration Date: 06/09/2012
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: GreenSquare Group Limited
+  Registration Number: 4833
+  Registration Date: 07/10/2016
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Greenwich Housing Society Limited
+  Registration Number: L0308
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Grimsby,Cleethorpes and Humber Region Y.M.C.A.
+  Registration Number: LH4152
+  Registration Date: 27/11/1997
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: GUHG 2018 Limited
+  Registration Number: L4518
+  Registration Date: 26/02/2008
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Guild Care
+  Registration Number: LH4106
+  Registration Date: 10/09/1996
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Guildford Borough Council
+  Registration Number: 43UD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Guildford Sunset Homes
+  Registration Number: LH0971
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Guinness Care and Support Limited
+  Registration Number: L4497
+  Registration Date: 01/10/2007
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Guinness Housing Association Limited
+  Registration Number: L2441
+  Registration Date: 11/07/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Habinteg Housing Association Limited
+  Registration Number: LH0459
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hackney Housing Co-operative Limited
+  Registration Number: C2744
+  Registration Date: 25/10/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hackney Parish Almshouses Charity
+  Registration Number: 4695
+  Registration Date: 07/03/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Halo Housing Association Limited
+  Registration Number: 4661
+  Registration Date: 03/06/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Halton Housing
+  Registration Number: L4456
+  Registration Date: 22/11/2005
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hamelin Trust Services Limited
+  Registration Number: 4685
+  Registration Date: 13/12/2011
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Hamlet Village Housing Co-operative Limited
+  Registration Number: C3724
+  Registration Date: 11/05/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hammersmith United Charities
+  Registration Number: A1789
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Hamwic Housing Co-operative Limited
+  Registration Number: C3772
+  Registration Date: 14/03/1988
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Harbour Light Assisted Living CIC
+  Registration Number: 4791
+  Registration Date: 05/06/2014
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: HARC Housing Association Limited
+  Registration Number: LH3594
+  Registration Date: 16/09/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Harefield Parochial Charities
+  Registration Number: A4354
+  Registration Date: 14/11/2002
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Haringey London Borough Council
+  Registration Number: 00AP
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Harlow District Council
+  Registration Number: 22UJ
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Harlow Poors Charities
+  Registration Number: A0163
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Harman Atwood For Almshouses and Curates House
+  Registration Number: A2323
+  Registration Date: 14/03/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Harpers Marsh and Crumps Almshouse Charity
+  Registration Number: A0458
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Harrison & Potter Trust
+  Registration Number: A1920
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Harrison Housing
+  Registration Number: A4410
+  Registration Date: 24/02/2004
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Harrogate Borough Council
+  Registration Number: 36UD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Harrogate Flower Fund Homes Limited
+  Registration Number: L1015
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Harrogate Housing Association Limited
+  Registration Number: L2188
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Harrogate Neighbours Housing Association Limited
+  Registration Number: H0705
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Harrow Churches Housing Association
+  Registration Number: L0923
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hartlepool Borough Council
+  Registration Number: 00EB
+  Registration Date: 09/12/2014
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Hassocks Housing Society Limited
+  Registration Number: L2173
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hastoe Housing Association Limited
+  Registration Number: L0018
+  Registration Date: 25/03/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hatch Row Housing Co-operative Limited
+  Registration Number: C2304
+  Registration Date: 14/03/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hatton Housing Trust Limited
+  Registration Number: L0938
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Havant Housing Association Limited
+  Registration Number: LH3889
+  Registration Date: 29/01/1990
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hawes Street Housing Limited
+  Registration Number: 4707
+  Registration Date: 05/04/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Hazel Housing Co-operative Limited
+  Registration Number: C3963
+  Registration Date: 21/01/1992
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Heart Of England Housing Association Limited
+  Registration Number: L4526
+  Registration Date: 01/04/2008
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Heart of England Young Men’s Christian Association
+  Registration Number: 4783
+  Registration Date: 15/11/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Heart of Medway Housing Association Ltd
+  Registration Number: 4634
+  Registration Date: 02/12/2010
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Heartsease House Community Interest Company
+  Registration Number: 4658
+  Registration Date: 25/05/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Heathview Tenants’ Co-operative Limited
+  Registration Number: C2390
+  Registration Date: 13/06/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Helen Peele Memorial Almshouses
+  Registration Number: A0379
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Helena Partnerships Limited
+  Registration Number: L4340
+  Registration Date: 26/06/2002
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hellens Residential Limited
+  Registration Number: 4744
+  Registration Date: 14/11/2012
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Hendon Christian Housing Association Limited
+  Registration Number: L1515
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Henley and District Housing Trust Limited
+  Registration Number: L1998
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Henley YMCA
+  Registration Number: 4847
+  Registration Date: 04/04/2017
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Henry Boys Almshouses
+  Registration Number: A4063
+  Registration Date: 01/02/1995
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Henry Pinnock & Victoria & Albert Memorial Charity
+  Registration Number: A3969
+  Registration Date: 21/01/1992
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Herefordshire Council
+  Registration Number: 5104
+  Registration Date: 02/10/2020
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Herring House Trust (Great Yarmouth)
+  Registration Number: LH4261
+  Registration Date: 21/03/2000
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Hesketh Street Housing Co-operative Limited
+  Registration Number: C2976
+  Registration Date: 10/03/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hewitt Homes
+  Registration Number: L1856
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Hexagon Housing Association Limited
+  Registration Number: L1538
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Heyford Regeneration Limited
+  Registration Number: 4796
+  Registration Date: 02/10/2014
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Heylo Housing Registered Provider Limited
+  Registration Number: 4668
+  Registration Date: 04/08/2011
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: HFL Homes Limited
+  Registration Number: 5064
+  Registration Date: 10/01/2019
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Hibbert Almshouse Charity
+  Registration Number: A2485
+  Registration Date: 12/09/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Hibiscus Housing Association Limited
+  Registration Number: H3853
+  Registration Date: 20/03/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: High Peak Borough Council
+  Registration Number: 17UH
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Highstone Housing Association Limited
+  Registration Number: 4776
+  Registration Date: 17/09/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Hightown Housing Association Limited
+  Registration Number: L2179
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hill Homes
+  Registration Number: LH1315
+  Registration Date: 26/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hilldale Housing Association Limited
+  Registration Number: 4760
+  Registration Date: 05/04/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Hillside Housing Trust Limited
+  Registration Number: L4447
+  Registration Date: 12/07/2005
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hinckley and Bosworth Borough Council
+  Registration Number: 31UE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Hirst Housing Co-operative Limited
+  Registration Number: C3454
+  Registration Date: 09/12/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Holmwood Tenants Co-operative Limited
+  Registration Number: C2206
+  Registration Date: 13/12/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Holt Road Area Housing Co-operative Limited
+  Registration Number: C3298
+  Registration Date: 12/07/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Holtspur Housing Association Limited
+  Registration Number: L4003
+  Registration Date: 15/12/1992
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Holy Trinity (Guildford) Housing Association Ltd
+  Registration Number: L1994
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Holyland Housing Co-Operative Limited
+  Registration Number: C2422
+  Registration Date: 13/01/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Home from Home Housing Association Limited
+  Registration Number: C3769
+  Registration Date: 14/03/1988
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Home Group Limited
+  Registration Number: L3076
+  Registration Date: 01/10/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Homeless Action Resource Project
+  Registration Number: 4742
+  Registration Date: 19/10/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Homes for Change Limited
+  Registration Number: C3891
+  Registration Date: 02/07/1990
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Homes for Wells Limited
+  Registration Number: 4785
+  Registration Date: 16/01/2014
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Homesdale (Woodford Baptist Homes) Limited
+  Registration Number: LH2021
+  Registration Date: 12/07/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Honeycomb Group Limited
+  Registration Number: LH2162
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hopton’s Charity
+  Registration Number: A2837
+  Registration Date: 16/07/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Horniman Housing Association Limited
+  Registration Number: LH3903
+  Registration Date: 19/03/1990
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hornsey (North London) YMCA Housing Society Ltd
+  Registration Number: H0995
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hornsey Housing Trust Limited
+  Registration Number: L0719
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hospital of St Mary The Virgin (Rye Hill & Benwell)
+  Registration Number: A1273
+  Registration Date: 26/01/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Hour Glass Housing Co-operative Limited
+  Registration Number: C3044
+  Registration Date: 14/07/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Housing 21
+  Registration Number: L0055
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Housing For Women
+  Registration Number: L0970
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Housing Pathways Trust
+  Registration Number: A0376
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Housing Solutions
+  Registration Number: L4073
+  Registration Date: 27/04/1995
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Howard Cottage Housing Association
+  Registration Number: L1312
+  Registration Date: 26/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hull and East Yorkshire Mind
+  Registration Number: 4828
+  Registration Date: 14/06/2016
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Hull Churches Housing Association Limited
+  Registration Number: L3305
+  Registration Date: 12/07/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hull House Improvement Society Limited
+  Registration Number: L2434
+  Registration Date: 11/07/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hull Resettlement Project Limited
+  Registration Number: H4310
+  Registration Date: 13/02/2001
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Hull United Charities
+  Registration Number: A0132
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Humankind Charity
+  Registration Number: 4713
+  Registration Date: 03/05/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Humphrey Booth Housing Charity
+  Registration Number: A0798
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Hundred Houses Society Limited
+  Registration Number: L0718
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hunslet Housing Co-operative Limited
+  Registration Number: C2586
+  Registration Date: 26/01/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hunton Bridge Cottage Trust
+  Registration Number: L2022
+  Registration Date: 12/07/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Hyde Housing Association Limited
+  Registration Number: LH0032
+  Registration Date: 16/04/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hyde Southbank Homes Limited
+  Registration Number: L4223
+  Registration Date: 08/06/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Hyelm
+  Registration Number: H0312
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: IKE Supported Housing Limited
+  Registration Number: 4822
+  Registration Date: 01/10/2015
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Imani Housing Co-operative Limited
+  Registration Number: C3755
+  Registration Date: 07/12/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Impact Housing Association Limited
+  Registration Number: L0917
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Inclusion Housing Community Interest Company
+  Registration Number: 4662
+  Registration Date: 08/06/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Incommunities Group Limited
+  Registration Number: L4363
+  Registration Date: 13/02/2003
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Incommunities Limited
+  Registration Number: L4476
+  Registration Date: 26/01/2007
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Innisfree Housing Association Limited
+  Registration Number: LH3829
+  Registration Date: 30/01/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Inquilab Housing Association Limited
+  Registration Number: LH3728
+  Registration Date: 22/07/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Ipswich Borough Council
+  Registration Number: 42UD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Iroko Housing Co-operative Limited
+  Registration Number: C4321
+  Registration Date: 17/07/2001
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Irwell Valley Housing Association Limited
+  Registration Number: L0061
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Isis Housing Co-operative Limited
+  Registration Number: C3770
+  Registration Date: 14/03/1988
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Island Cottages Limited
+  Registration Number: L1815
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Isleworth and Hounslow Charity Limited
+  Registration Number: 4675
+  Registration Date: 14/10/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Islington and Shoreditch Housing Association Limited
+  Registration Number: L0457
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Islington Community Housing Co-operative Limited
+  Registration Number: C2579
+  Registration Date: 12/12/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: J & M Residential Lettings Limited
+  Registration Number: 4737
+  Registration Date: 24/09/2012
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Jacob Wright’s Cottages
+  Registration Number: A2293
+  Registration Date: 14/02/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: James Bradford Almshouses Trust
+  Registration Number: A2989
+  Registration Date: 28/04/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Jane Cameron’s Old Peoples Charity
+  Registration Number: A1254
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Jane Gibson Almshouses
+  Registration Number: A0567
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Jewish Community Housing Association Limited
+  Registration Number: LH0902
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Jigsaw Homes Group Limited
+  Registration Number: LH4345
+  Registration Date: 09/07/2002
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Jigsaw Homes Midlands
+  Registration Number: L4532
+  Registration Date: 14/10/2008
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Joel Emanuel Trust
+  Registration Number: A2670
+  Registration Date: 22/05/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: John Bowley and Sherwood Almshouses
+  Registration Number: A0513
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: John Higgs Almshouses
+  Registration Number: A3457
+  Registration Date: 05/12/1983
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: John Horne Homes
+  Registration Number: A1194
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: John Pease Cottages
+  Registration Number: A3970
+  Registration Date: 21/01/1992
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: ‘Johnnie’ Johnson Housing Trust Limited
+  Registration Number: L1231
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Joseph and Eleanor Gunson Almshouse Trust
+  Registration Number: A1442
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Joseph Chariott’s Charity
+  Registration Number: A2067
+  Registration Date: 30/07/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Joseph Crossley’s Almshouses
+  Registration Number: A1274
+  Registration Date: 26/01/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Joseph Rowntree Housing Trust
+  Registration Number: 5079
+  Registration Date: 21/11/2019
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Julian House
+  Registration Number: L4549
+  Registration Date: 04/02/2010
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Kaleidoscope (Kingston) Housing Association Limited
+  Registration Number: LH0117
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Karbon Homes Limited
+  Registration Number: 4846
+  Registration Date: 03/04/2017
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Karin Housing Association Limited
+  Registration Number: 4770
+  Registration Date: 11/06/2013
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Keelman Homes Limited
+  Registration Number: 4647
+  Registration Date: 07/03/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Kendal Almshouse Charity
+  Registration Number: 5097
+  Registration Date: 13/07/2020
+  Designation: Non-Profit
+  Corporate Form: CIO-Charitable Incorporated Organisation
+-
+  Organisation Name: Keniston Housing Association Limited
+  Registration Number: L1965
+  Registration Date: 10/08/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Kentish Homes Limited
+  Registration Number: 4823
+  Registration Date: 18/12/2015
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Keswick Community Housing Trust
+  Registration Number: 4712
+  Registration Date: 03/05/2012
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Kettering Borough Council
+  Registration Number: 34UE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Keystage Properties Limited
+  Registration Number: 4725
+  Registration Date: 12/07/2012
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Keyworkers Housing Association Limited
+  Registration Number: 4667
+  Registration Date: 20/07/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Kilburn Housing Co-operative Limited
+  Registration Number: C2694
+  Registration Date: 28/06/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: King George V Memorial Houses
+  Registration Number: A2250
+  Registration Date: 17/01/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: King’s Barton Housing Association Limited
+  Registration Number: L1716
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Kingsclere Almshouses Charity
+  Registration Number: A0486
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Kingston upon Hull City Council
+  Registration Number: 00FA
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Kingston upon Thames Churches Housing Association Limited
+  Registration Number: L0891
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Kinsman Housing Limited
+  Registration Number: 4769
+  Registration Date: 06/06/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Kirkdale Housing Co-operative Limited
+  Registration Number: C3347
+  Registration Date: 25/10/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Kirklees Housing Association Limited
+  Registration Number: 4735
+  Registration Date: 13/09/2012
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Kirklees Metropolitan Borough Council
+  Registration Number: 00CZ
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Knowsley Residents Housing Co-operative Limited
+  Registration Number: C3573
+  Registration Date: 17/06/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Kurdish Housing Association
+  Registration Number: L4544
+  Registration Date: 03/09/2009
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lace Housing Limited
+  Registration Number: L0438
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lady Lumley’s Almshouses
+  Registration Number: A3567
+  Registration Date: 11/03/1985
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Ladybur Housing Co-operative Limited
+  Registration Number: C1686
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lambeth & Southwark Housing Association Limited
+  Registration Number: L0927
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lambeth Self Help Housing Association Limited
+  Registration Number: L4346
+  Registration Date: 09/07/2002
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lammerton Housing Co-operative Limited
+  Registration Number: C3690
+  Registration Date: 08/09/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lancaster City Council
+  Registration Number: 30UH
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Langley House Trust
+  Registration Number: 4693
+  Registration Date: 01/03/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Langrove Community Housing Co-operative Limited
+  Registration Number: C3777
+  Registration Date: 14/03/1988
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Larch Housing Association Limited
+  Registration Number: 4727
+  Registration Date: 23/07/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Larcombe Housing Association Limited
+  Registration Number: H0895
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lark Lane Housing Co-operative Limited
+  Registration Number: C2416
+  Registration Date: 13/06/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lawrence Campe’s Almshouse Trust
+  Registration Number: A2064
+  Registration Date: 30/07/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Leasowe Community Homes Limited
+  Registration Number: L4195
+  Registration Date: 24/11/1998
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Leazes Homes Limited
+  Registration Number: 4633
+  Registration Date: 02/12/2010
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Leeds and Yorkshire Housing Association Limited
+  Registration Number: LH0704
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Leeds City Council
+  Registration Number: 00DA
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Leeds Federated Housing Association Limited
+  Registration Number: LH0989
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Leeds Jewish Housing Association Limited
+  Registration Number: L0440
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Legal & General Affordable Homes Limited
+  Registration Number: 5062
+  Registration Date: 06/12/2018
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Leicester City Council
+  Registration Number: 00FN
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Leicester YMCA
+  Registration Number: H2381
+  Registration Date: 09/05/1977
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Lench’s Trust
+  Registration Number: A2074
+  Registration Date: 30/07/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Leta-Claudia Streets Housing Co-operative Limited
+  Registration Number: C3207
+  Registration Date: 14/09/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lets for Life
+  Registration Number: 4863
+  Registration Date: 05/12/2017
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Lewes District Council
+  Registration Number: 21UF
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Lewisham Family Co-operative Association Limited
+  Registration Number: C2313
+  Registration Date: 14/03/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Leytonstone Housing Co-operative Limited
+  Registration Number: C3674
+  Registration Date: 21/07/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Life 2009
+  Registration Number: 4734
+  Registration Date: 06/09/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Lightbown Cottage Home Trust
+  Registration Number: A3358
+  Registration Date: 06/12/1982
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Lincolnshire Employment Accommodation Project Limited
+  Registration Number: 4795
+  Registration Date: 10/09/2014
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Lincolnshire Housing Partnership Limited
+  Registration Number: 4877
+  Registration Date: 06/04/2018
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lincolnshire Rural Housing Association Limited
+  Registration Number: L3698
+  Registration Date: 20/10/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lincolnshire Y.M.C.A. Ltd
+  Registration Number: H2676
+  Registration Date: 22/05/1978
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Linden First Limited
+  Registration Number: 4752
+  Registration Date: 22/02/2013
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Lindsey Housing Co-operative Limited
+  Registration Number: C3441
+  Registration Date: 12/09/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Littlehampton & Rustington Housing Society Limited
+  Registration Number: L1255
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Liverpool City Council
+  Registration Number: 5074
+  Registration Date: 16/08/2019
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Liverpool Gingerbread Housing Co-operative Limited
+  Registration Number: C2849
+  Registration Date: 16/07/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Liverpool Jewish Housing Association Limited
+  Registration Number: L0063
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: LiveWest Homes Limited
+  Registration Number: 4873
+  Registration Date: 14/03/2018
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Livin Housing Limited
+  Registration Number: L4538
+  Registration Date: 05/03/2009
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Livv Housing Group
+  Registration Number: LH4343
+  Registration Date: 09/07/2002
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Local Space
+  Registration Number: LH4454
+  Registration Date: 07/11/2005
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Locking Deanery Housing Society Limited
+  Registration Number: H1972
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Loddon Homes Limited
+  Registration Number: 4827
+  Registration Date: 10/06/2016
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Lodge Lane East Co-operative Housing Limited
+  Registration Number: C0508
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: London & Quadrant Housing Trust
+  Registration Number: L4517
+  Registration Date: 31/03/2008
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: London Borough of Barking and Dagenham
+  Registration Number: 00AB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Barnet
+  Registration Number: 00AC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Bexley
+  Registration Number: 00AD
+  Registration Date: 09/10/2013
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Brent
+  Registration Number: 00AE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Bromley
+  Registration Number: 5103
+  Registration Date: 29/09/2020
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Camden Council
+  Registration Number: 00AG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Croydon
+  Registration Number: 00AH
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Ealing
+  Registration Number: 00AJ
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Enfield
+  Registration Number: 00AK
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Greenwich
+  Registration Number: 00AL
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Hackney
+  Registration Number: 00AM
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Hammersmith and Fulham
+  Registration Number: 00AN
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Harrow
+  Registration Number: 00AQ
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Havering Council
+  Registration Number: 00AR
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Hillingdon
+  Registration Number: 00AS
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Hounslow
+  Registration Number: 00AT
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Islington
+  Registration Number: 00AU
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Lambeth
+  Registration Number: 00AY
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Lewisham
+  Registration Number: 00AZ
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Merton
+  Registration Number: 00BA
+  Registration Date: 26/03/2015
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Newham
+  Registration Number: 00BB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Redbridge
+  Registration Number: 00BC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Sutton
+  Registration Number: 00BF
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Tower Hamlets
+  Registration Number: 00BG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Waltham Forest
+  Registration Number: 00BH
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Borough of Wandsworth
+  Registration Number: 00BJ
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: London Cyrenians Housing Limited
+  Registration Number: LH4377
+  Registration Date: 20/03/2003
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Longdendale Housing Society Limited
+  Registration Number: L1710
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Longhurst & Havelok Homes Limited
+  Registration Number: L4542
+  Registration Date: 01/10/2009
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Longhurst Group Limited
+  Registration Number: L4277
+  Registration Date: 08/06/2000
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Longlife Housing Co-operative Limited
+  Registration Number: C3272
+  Registration Date: 26/04/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Look Ahead Care and Support Limited
+  Registration Number: LH0013
+  Registration Date: 25/03/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lord Mayor of Portsmouth’s Coronation Homes Ltd.
+  Registration Number: L4207
+  Registration Date: 25/02/1999
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Louisa Cottages Charity
+  Registration Number: A1892
+  Registration Date: 27/05/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Lowestoft Church & Town Almshouse Charity
+  Registration Number: A1160
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Lumen Housing Limited
+  Registration Number: 5106
+  Registration Date: 01/10/2020
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lune Valley Rural Housing Association Limited
+  Registration Number: L3880
+  Registration Date: 04/12/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Luton Borough Council
+  Registration Number: 00KA
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Luton Community Housing Limited
+  Registration Number: L1518
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lyng Community Association
+  Registration Number: L4420
+  Registration Date: 11/05/2004
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Lynsted Housing Co-operative Limited
+  Registration Number: C4112
+  Registration Date: 10/09/1996
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Lyvennet Community Trust
+  Registration Number: 4630
+  Registration Date: 28/09/2010
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: M&G UK Shared Ownership Limited
+  Registration Number: 5115
+  Registration Date: 05/11/2020
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Magenta Living
+  Registration Number: L4435
+  Registration Date: 18/01/2005
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Magna Housing Limited
+  Registration Number: 4844
+  Registration Date: 31/03/2017
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Maidstone Borough Council
+  Registration Number: 29UH
+  Registration Date: 26/03/2014
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Major Housing Association Limited
+  Registration Number: 4637
+  Registration Date: 25/01/2011
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Maldon Housing Association Limited
+  Registration Number: L1551
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Malins Affordable Homes Limited
+  Registration Number: 4777
+  Registration Date: 03/10/2013
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Manchester City Council
+  Registration Number: 00BN
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Manchester Jewish Housing Association
+  Registration Number: L1714
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Manchester Unity Housing Association Limited
+  Registration Number: L0406
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Manningham Housing Association Limited
+  Registration Number: L3736
+  Registration Date: 22/06/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Mansfield District Council
+  Registration Number: 37UF
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Mansfield Road (Nottingham) Baptist Housing Association Limited
+  Registration Number: LH0959
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Margaret Colquhoun Chavasse Almshouses
+  Registration Number: A3697
+  Registration Date: 08/09/1986
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Margaret Hyde Charity
+  Registration Number: A3387
+  Registration Date: 14/03/1983
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Marlborough & District Housing Association Limited
+  Registration Number: L1031
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Marsden Memorial Homes
+  Registration Number: A3822
+  Registration Date: 05/12/1988
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Marshfield Consolidated Charities
+  Registration Number: A0318
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Martlet Homes Limited
+  Registration Number: L4303
+  Registration Date: 13/02/2001
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Mary Hannah Almshouses
+  Registration Number: A4039
+  Registration Date: 15/03/1994
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Mary Hatch Almshouses with Diamond Jubilee Cottages
+  Registration Number: A3909
+  Registration Date: 19/03/1990
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Masonic Housing Association
+  Registration Number: L0673
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: May Day Permanent Housing Co-operative Limited
+  Registration Number: C3557
+  Registration Date: 11/03/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Maynard Co-operative Housing Association Limited
+  Registration Number: C2462
+  Registration Date: 14/09/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Medway Council
+  Registration Number: 00LC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Melton Borough Council
+  Registration Number: 31UG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Mercy House of William Fry
+  Registration Number: A2600
+  Registration Date: 13/02/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Merlin Housing Society Limited
+  Registration Number: L4485
+  Registration Date: 30/01/2007
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Mersea Island Trust
+  Registration Number: L1259
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Methodist Homes Housing Association Limited
+  Registration Number: LH2343
+  Registration Date: 30/03/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Metropolitan Benefit Societies’ Almshouses
+  Registration Number: A3634
+  Registration Date: 27/01/1986
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Metropolitan Housing Trust Limited
+  Registration Number: L0726
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Mid Devon District Council
+  Registration Number: 18UD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Mid Suffolk District Council
+  Registration Number: 42UE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Middlesbrough Council
+  Registration Number: 00EC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Midland Heart Limited
+  Registration Number: L4466
+  Registration Date: 01/04/2006
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Mill Street Co-operative Limited
+  Registration Number: C3396
+  Registration Date: 09/05/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Millat Asian Housing Association Limited
+  Registration Number: L3974
+  Registration Date: 24/03/1992
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Milldale Housing Co-operative Limited
+  Registration Number: C3285
+  Registration Date: 07/06/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Miller Walk Housing Co-operative Limited
+  Registration Number: C3637
+  Registration Date: 17/03/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Milton Keynes Council
+  Registration Number: 00MG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Milton Keynes YMCA Limited
+  Registration Number: 4870
+  Registration Date: 08/03/2018
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Minster Housing Co-operative Limited
+  Registration Number: C4113
+  Registration Date: 10/09/1996
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Mitre Housing Association Limited
+  Registration Number: LH1704
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Moat Farm Housing Co-operative Limited
+  Registration Number: C3627
+  Registration Date: 27/01/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Moat Homes Limited
+  Registration Number: L0386
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Moat Housing Group Limited
+  Registration Number: L4047
+  Registration Date: 20/09/1994
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Mole Valley District Council
+  Registration Number: 43UE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Monmouth Road Housing Co-operative Limited
+  Registration Number: C2903
+  Registration Date: 22/10/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Mortlake Almshouse and Relief Charities
+  Registration Number: A2312
+  Registration Date: 14/03/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Mossbank Homes Limited
+  Registration Number: SL3447
+  Registration Date: 24/10/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Mosscare St. Vincent’s Housing Group Limited
+  Registration Number: 4857
+  Registration Date: 31/07/2017
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Mount Green Housing Association Limited
+  Registration Number: L0042
+  Registration Date: 16/04/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Mrs H Frances Le Personne Benevolent Trust
+  Registration Number: A0056
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: MTD Housing Limited
+  Registration Number: 5063
+  Registration Date: 18/12/2018
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Muir Group Housing Association Limited
+  Registration Number: L2194
+  Registration Date: 10/11/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: MuirCroft Housing Association Limited
+  Registration Number: L1253
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Mulberry Housing Co-operative Limited
+  Registration Number: C3635
+  Registration Date: 07/02/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Municipal & Owen Carter Almshouse Charities
+  Registration Number: A3266
+  Registration Date: 01/03/1982
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Municipal Charities
+  Registration Number: A0736
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: My Space Housing Solutions
+  Registration Number: 4779
+  Registration Date: 03/10/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: NACRO
+  Registration Number: 4781
+  Registration Date: 03/10/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: National Council of Young Men’s Christian Associations (Incorporated)
+  Registration Number: LH2204
+  Registration Date: 13/12/1976
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Nehemiah United Churches Housing Association Limited
+  Registration Number: L3833
+  Registration Date: 30/01/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Network Homes Limited
+  Registration Number: 4825
+  Registration Date: 29/04/2016
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: New Charter Homes Limited
+  Registration Number: LH4266
+  Registration Date: 21/03/2000
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: New Forest District Council
+  Registration Number: 24UJ
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: New Forest Villages Housing Association Limited
+  Registration Number: L3704
+  Registration Date: 01/12/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: New Foundations Housing Association Limited
+  Registration Number: 4666
+  Registration Date: 19/07/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: New Longsight Housing Co-operative Limited
+  Registration Number: C3574
+  Registration Date: 17/06/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: New Moves Housing Co-operative Limited
+  Registration Number: C3628
+  Registration Date: 03/02/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: New Outlook Housing Association Limited
+  Registration Number: H0924
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: New Roots Limited
+  Registration Number: 4798
+  Registration Date: 06/11/2014
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: New Swift Housing Co-operative Limited
+  Registration Number: C2548
+  Registration Date: 12/12/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: New Venture Housing Co-operative Limited
+  Registration Number: C3409
+  Registration Date: 20/06/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: New Walk Property Management CIC
+  Registration Number: 4763
+  Registration Date: 16/04/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: New World Housing Association Limited
+  Registration Number: LH3980
+  Registration Date: 28/04/1992
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Newark and Sherwood District Council
+  Registration Number: 37UG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Newark Emmaus Trust
+  Registration Number: 4640
+  Registration Date: 14/01/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Newark Housing Association Limited
+  Registration Number: L0961
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Newcastle City Council
+  Registration Number: 00CJ
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Newleaf Housing Co-operative Limited
+  Registration Number: C3026
+  Registration Date: 09/06/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Newlon Housing Trust
+  Registration Number: L0006
+  Registration Date: 20/03/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Nicholas Chamberlaine’s Hospital & Sermon Charity
+  Registration Number: A0582
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: North Camden Housing Co-operative Limited
+  Registration Number: C3024
+  Registration Date: 09/06/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: North Devon Homes
+  Registration Number: LH4249
+  Registration Date: 03/02/2000
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: North East Derbyshire District Council
+  Registration Number: 17UJ
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: North Eastern YWCA Trustees Limited
+  Registration Number: H2168
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: North Kesteven District Council
+  Registration Number: 32UE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: North London Muslim Housing Association Limited
+  Registration Number: LH3859
+  Registration Date: 15/05/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: North Norfolk District Council
+  Registration Number: 5098
+  Registration Date: 07/08/2020
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: North Somerset Council
+  Registration Number: 00HC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: North Star Housing Group
+  Registration Number: LH0084
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: North Tyneside Council
+  Registration Number: 00CK
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: North Warwickshire Borough Council
+  Registration Number: 44UB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: North West Leicestershire District Council
+  Registration Number: 31UH
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Northampton Borough Council
+  Registration Number: 34UF
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Northamptonshire Rural Housing Association Limited
+  Registration Number: L3981
+  Registration Date: 28/04/1992
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Northborough Housing Co-operative Limited
+  Registration Number: C2850
+  Registration Date: 16/07/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Northchapel, Petworth and Tillington Almshouses
+  Registration Number: A2405
+  Registration Date: 13/06/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Northumberland County Council
+  Registration Number: 00EM
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Norton Housing and Support Ltd
+  Registration Number: 4676
+  Registration Date: 14/10/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Norwich City Council
+  Registration Number: 33UG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Norwich Consolidated Charities
+  Registration Number: A0485
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Norwich Housing Society Limited
+  Registration Number: L1405
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Notting Dale Housing Co-operative Limited
+  Registration Number: C3517
+  Registration Date: 29/10/1984
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Notting Hill Genesis
+  Registration Number: 4880
+  Registration Date: 16/04/2018
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Notting Hill Home Ownership Limited
+  Registration Number: SL3119
+  Registration Date: 26/01/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Nottingham City Council
+  Registration Number: 00FY
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Nottingham City Homes Registered Provider Limited
+  Registration Number: 4862
+  Registration Date: 09/11/2017
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Nottingham Community (Second) Housing Association Limited
+  Registration Number: SL3169
+  Registration Date: 08/06/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Nottingham Community Housing Association Limited
+  Registration Number: 4817
+  Registration Date: 08/04/2015
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Nottinghamshire YMCA
+  Registration Number: H3286
+  Registration Date: 07/06/1982
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: NSAH (Alliance Homes) Limited
+  Registration Number: L4459
+  Registration Date: 24/01/2006
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: NSHG 2020 Limited
+  Registration Number: L4468
+  Registration Date: 23/05/2006
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Nuneaton And Bedworth Borough Council
+  Registration Number: 44UC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Oadby and Wigston Borough Council
+  Registration Number: 31UJ
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Oak Housing Limited
+  Registration Number: 4720
+  Registration Date: 15/06/2012
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Oakapple Housing Co-operative Limited
+  Registration Number: C4101
+  Registration Date: 28/05/1996
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Oast Wood Housing Co-operative Limited
+  Registration Number: C4042
+  Registration Date: 09/05/1994
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Ocean Housing Group Limited
+  Registration Number: L4422
+  Registration Date: 11/05/2004
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Ocean Housing Limited
+  Registration Number: LH4248
+  Registration Date: 03/02/2000
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Ockley Housing Association Limited
+  Registration Number: L0067
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Octavia Housing
+  Registration Number: L0717
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Odu-Dua Housing Association Limited
+  Registration Number: L3757
+  Registration Date: 07/12/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Old Ben Homes Limited
+  Registration Number: A1843
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Old Cleeve Memorial Cottages
+  Registration Number: A0564
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Old Etonian Housing Association Limited
+  Registration Number: L2000
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Old Farm Park Housing Co-operative Limited
+  Registration Number: C3992
+  Registration Date: 22/09/1992
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Old Isleworth Housing Co-operative Limited
+  Registration Number: C3726
+  Registration Date: 11/05/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Oldham Metropolitan Borough Council
+  Registration Number: 00BP
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Omega Housing Limited
+  Registration Number: 4635
+  Registration Date: 02/12/2010
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: One Housing Group Limited
+  Registration Number: LH0171
+  Registration Date: 23/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: One Manchester Limited
+  Registration Number: 4808
+  Registration Date: 05/02/2015
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: One Vision Housing Limited
+  Registration Number: 4804
+  Registration Date: 03/02/2015
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: One YMCA
+  Registration Number: H4418
+  Registration Date: 23/03/2004
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Ongo Homes Limited
+  Registration Number: L4486
+  Registration Date: 30/01/2007
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Onward Group Limited
+  Registration Number: 4649
+  Registration Date: 01/04/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Onward Homes Limited
+  Registration Number: LH0250
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Optima Community Association
+  Registration Number: L4228
+  Registration Date: 16/06/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Optivo
+  Registration Number: 4851
+  Registration Date: 31/05/2017
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Orbit Group Limited
+  Registration Number: L4123
+  Registration Date: 19/03/1997
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Orbit South Housing Association Limited
+  Registration Number: L4060
+  Registration Date: 13/12/1994
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Orchard & Shipman Homes Limited
+  Registration Number: 4699
+  Registration Date: 29/03/2012
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Orchard Homes
+  Registration Number: A0072
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Orchard Housing Society Limited
+  Registration Number: L1322
+  Registration Date: 26/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Oriel Housing Limited
+  Registration Number: LH4162
+  Registration Date: 17/02/1998
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Origin Housing 2 Limited
+  Registration Number: 4766
+  Registration Date: 02/05/2013
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Origin Housing Limited
+  Registration Number: L0871
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Orts Road Housing Co-operative Limited
+  Registration Number: C2046
+  Registration Date: 13/03/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Orwell Housing Association Limited
+  Registration Number: L0028
+  Registration Date: 25/03/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Otto Schiff Housing Association
+  Registration Number: LH1836
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Outreach Housing Limited
+  Registration Number: 5095
+  Registration Date: 04/06/2020
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Oxfield Housing Co-operative Association Limited
+  Registration Number: C3277
+  Registration Date: 26/04/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Oxford City Council
+  Registration Number: 38UC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: P3 Housing Limited
+  Registration Number: 4876
+  Registration Date: 05/04/2018
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Paddock Housing Co-operative Limited
+  Registration Number: C3607
+  Registration Date: 07/01/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Padley Housing Association Limited
+  Registration Number: L2498
+  Registration Date: 12/09/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Palm Housing Co-operative Limited
+  Registration Number: C4044
+  Registration Date: 09/05/1994
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Pan African Refugee Housing Co-operative Limited
+  Registration Number: C3650
+  Registration Date: 27/03/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Paradigm Homes Charitable Housing Association Limited
+  Registration Number: LH4138
+  Registration Date: 09/09/1997
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Paradigm Housing Group Limited
+  Registration Number: L4215
+  Registration Date: 16/03/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Paradise Housing Co-operative Limited
+  Registration Number: C3128
+  Registration Date: 26/01/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Paragon Asra Housing Limited
+  Registration Number: 4849
+  Registration Date: 25/04/2017
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Parasol Homes Limited
+  Registration Number: 4728
+  Registration Date: 20/07/2012
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Park Hill Housing Co-operative Limited
+  Registration Number: C3636
+  Registration Date: 17/03/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Park Properties Housing Association Ltd
+  Registration Number: 5056
+  Registration Date: 06/09/2018
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Parkway Green Housing Trust
+  Registration Number: L4478
+  Registration Date: 10/10/2006
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Parson Latham’s Hospital In Barnwell
+  Registration Number: A2759
+  Registration Date: 04/12/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Partners Foundation Limited
+  Registration Number: 4768
+  Registration Date: 15/05/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Passage Housing Services
+  Registration Number: 4842
+  Registration Date: 07/03/2017
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Peabody Developments Limited
+  Registration Number: L3885
+  Registration Date: 29/01/1990
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Peabody South East Limited
+  Registration Number: 4869
+  Registration Date: 02/03/2018
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Peabody Trust
+  Registration Number: 4878
+  Registration Date: 09/04/2018
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Peace Cottages Charity
+  Registration Number: A3648
+  Registration Date: 17/03/1986
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Peacehaven and Telscombe Housing Association Ltd
+  Registration Number: L1512
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Peak District Rural Housing Association Limited
+  Registration Number: L3899
+  Registration Date: 19/03/1990
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Peal Community Housing Limited
+  Registration Number: 5061
+  Registration Date: 06/12/2018
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Pearman Street Co-operative Limited
+  Registration Number: C2412
+  Registration Date: 13/06/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Pearson’s & St Elizabeth’s Cottage Homes
+  Registration Number: A1348
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Peel Street Housing Co-operative Limited
+  Registration Number: C2938
+  Registration Date: 14/12/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Penge Churches Housing Association Limited
+  Registration Number: L1243
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Penn and Widow Smith Almshouses
+  Registration Number: A2334
+  Registration Date: 23/03/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: People First Housing Association Limited
+  Registration Number: L4088
+  Registration Date: 25/01/1996
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Perry Almshouses
+  Registration Number: A0600
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Perryviews Housing Co-operative Limited
+  Registration Number: C3739
+  Registration Date: 22/06/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Peter Bedford Housing Association Limited
+  Registration Number: LH0888
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Peter Birtwistle Trust
+  Registration Number: 5086
+  Registration Date: 06/03/2020
+  Designation: Non-Profit
+  Corporate Form: CIO-Charitable Incorporated Organisation
+-
+  Organisation Name: Peter Birtwistle Trust
+  Registration Number: A4021
+  Registration Date: 14/12/1993
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Peterborough City Council
+  Registration Number: 5112
+  Registration Date: 02/11/2020
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: PHA Homes Ltd
+  Registration Number: L0244
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Phoenix Community Housing Association (Bellingham and Downham) Limited
+  Registration Number: L4505
+  Registration Date: 13/11/2007
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Phoenix Community Housing Co-operative Limited
+  Registration Number: C3556
+  Registration Date: 11/03/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Phoenix House
+  Registration Number: H3795
+  Registration Date: 05/09/1988
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Pickering and Ferens Homes
+  Registration Number: A4020
+  Registration Date: 23/11/1993
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Pierhead Housing Association Limited
+  Registration Number: L1001
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Pine Court Housing Association Limited
+  Registration Number: L3692
+  Registration Date: 08/09/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Pine Ridge Housing Association Limited
+  Registration Number: L1958
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Pine Tree Housing Co-operative Limited
+  Registration Number: C4102
+  Registration Date: 28/05/1996
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Pinnacle Spaces Limited
+  Registration Number: 4700
+  Registration Date: 29/03/2012
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Pinner House Society Limited
+  Registration Number: L1533
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Pioneer Co-operative Housing (Redditch) Limited
+  Registration Number: C4380
+  Registration Date: 20/03/2003
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Pivotal Housing Association
+  Registration Number: 4747
+  Registration Date: 15/01/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Places for People Group Limited
+  Registration Number: L4236
+  Registration Date: 21/09/1999
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Places for People Homes Limited
+  Registration Number: L0659
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Places for People Living+ Limited
+  Registration Number: LH3926
+  Registration Date: 10/09/1990
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Platform Housing Group Limited
+  Registration Number: 4789
+  Registration Date: 20/03/2014
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Platform Housing Limited
+  Registration Number: 5084
+  Registration Date: 10/01/2020
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Plexus UK (First Project) Limited
+  Registration Number: 4757
+  Registration Date: 18/03/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Plumlife Homes Limited
+  Registration Number: SL3224
+  Registration Date: 26/10/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Plus Dane Housing Limited
+  Registration Number: L4556
+  Registration Date: 26/07/2010
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Plymouth Charity Trust
+  Registration Number: A4273
+  Registration Date: 21/03/2000
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Plymouth Community Homes Limited
+  Registration Number: L4543
+  Registration Date: 03/09/2009
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Polish Citizens Committee Housing Association Ltd
+  Registration Number: H0007
+  Registration Date: 20/03/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Polish Retired Persons Housing Association Limited
+  Registration Number: L0119
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Poole Old Peoples Welfare and Housing Society Limited
+  Registration Number: L2205
+  Registration Date: 13/12/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Poplar Housing And Regeneration Community Association Limited
+  Registration Number: L4170
+  Registration Date: 17/03/1998
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Populo Homes
+  Registration Number: 5114
+  Registration Date: 05/11/2020
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Portal Housing Association Limited
+  Registration Number: LH4163
+  Registration Date: 17/02/1998
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Porthove Housing Association Limited
+  Registration Number: L0011
+  Registration Date: 25/03/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Portman House
+  Registration Number: H1653
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Portobello Housing Co-operative Limited
+  Registration Number: C3338
+  Registration Date: 13/09/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Portsmouth Churches Housing Association Limited
+  Registration Number: H2739
+  Registration Date: 25/10/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Portsmouth City Council
+  Registration Number: 00MR
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Portsmouth Rotary Housing Association Limited
+  Registration Number: L0686
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Preferred Homes Limited
+  Registration Number: 5093
+  Registration Date: 02/04/2020
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Prestwich & North Western Housing Association Ltd
+  Registration Number: L2036
+  Registration Date: 12/07/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Prime Focus Regeneration Group Limited
+  Registration Number: LH4275
+  Registration Date: 08/06/2000
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Prince Albert Gardens Housing Co-operative Limited
+  Registration Number: C3172
+  Registration Date: 08/06/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Progress Housing Association Limited
+  Registration Number: LH4032
+  Registration Date: 28/02/1994
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Progress Housing Group Limited
+  Registration Number: LH4189
+  Registration Date: 10/09/1998
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Project 34
+  Registration Number: 4800
+  Registration Date: 04/12/2014
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Prospect Housing Limited
+  Registration Number: 4750
+  Registration Date: 07/02/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Providence Row Housing Association
+  Registration Number: L0695
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Purlin Housing Co-operative Limited
+  Registration Number: C3530
+  Registration Date: 03/12/1984
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Puttenham & Wanborough Housing Society Limited
+  Registration Number: L0908
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Quadrant-Brownswood Tenant Co-operative Limited
+  Registration Number: C2157
+  Registration Date: 22/02/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Quo Vadis Trust
+  Registration Number: 4703
+  Registration Date: 29/03/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Radcliffe Housing Society Limited
+  Registration Number: L2159
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Railway Housing Association and Benefit Fund
+  Registration Number: A1855
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Ramsey Welfare Charities
+  Registration Number: A2945
+  Registration Date: 28/01/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Rapport Housing and Care
+  Registration Number: H2362
+  Registration Date: 18/04/1977
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Raven Housing Trust Limited
+  Registration Number: L4334
+  Registration Date: 20/03/2002
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Ravenscroft Re-Build Co-operative Limited
+  Registration Number: C3826
+  Registration Date: 05/12/1988
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Rayner House and Yew Trees Limited
+  Registration Number: H3182
+  Registration Date: 08/06/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: RCVDA Community Housing C.I.C
+  Registration Number: 5108
+  Registration Date: 01/10/2020
+  Designation: Non-Profit
+  Corporate Form: CIC-Community Interest Company
+-
+  Organisation Name: Reading Borough Council
+  Registration Number: 00MC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Reading YMCA
+  Registration Number: L4551
+  Registration Date: 04/03/2010
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Red Devon Housing Limited
+  Registration Number: H0670
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Red House Farm Housing Co-operative Limited
+  Registration Number: C3771
+  Registration Date: 14/03/1988
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Red Kite Community Housing Limited
+  Registration Number: 4682
+  Registration Date: 03/11/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Redditch Borough Council
+  Registration Number: 47UD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Redditch Co-operative 2000 Limited
+  Registration Number: C4378
+  Registration Date: 20/03/2003
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Redditch Friends Housing Association Limited
+  Registration Number: L1812
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Redwing Living Limited
+  Registration Number: L0877
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Redwood Housing Co-operative Limited
+  Registration Number: C3686
+  Registration Date: 21/07/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Refuge
+  Registration Number: 4730
+  Registration Date: 13/08/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Regenda Limited
+  Registration Number: 4653
+  Registration Date: 28/04/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Reigate Quaker Housing Association Limited
+  Registration Number: L0387
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Reliance Social Housing C.I.C
+  Registration Number: 4778
+  Registration Date: 03/10/2013
+  Designation: Non-Profit
+  Corporate Form: CIC-Community Interest Company
+-
+  Organisation Name: ReSI Homes Limited
+  Registration Number: 5092
+  Registration Date: 23/03/2020
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: ReSI Housing Limited
+  Registration Number: 5053
+  Registration Date: 05/07/2018
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Reside Housing Association Limited
+  Registration Number: 4745
+  Registration Date: 14/12/2012
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Resthaven Almshouses
+  Registration Number: A4136
+  Registration Date: 21/05/1997
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Retail Trust
+  Registration Number: L4362
+  Registration Date: 16/01/2003
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Retirement Lease Housing Association
+  Registration Number: L1967
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Rex Housing Limited
+  Registration Number: 4824
+  Registration Date: 03/03/2016
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Ribble Valley Borough Council
+  Registration Number: 30UL
+  Registration Date: 13/04/2016
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Richard Whitaker’s Almshouses
+  Registration Number: A3469
+  Registration Date: 23/01/1984
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Richmond Avenue Housing Co-operative Limited
+  Registration Number: C3043
+  Registration Date: 14/07/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Richmond Co-operative Housing Association Limited
+  Registration Number: C2693
+  Registration Date: 28/06/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Richmond Housing Partnership Limited
+  Registration Number: L4279
+  Registration Date: 08/06/2000
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Richmondshire District Council
+  Registration Number: 36UE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Rickmansworth Churches Housing Association Limited
+  Registration Number: L0892
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Ripon Municipal Charities
+  Registration Number: A3244
+  Registration Date: 07/12/1981
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Ripon YMCA
+  Registration Number: LH3651
+  Registration Date: 21/04/1986
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Riverside Housing Co-operative (Redditch) Limited
+  Registration Number: C4381
+  Registration Date: 20/03/2003
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Robert Hibbert’s Almshouse Charity
+  Registration Number: A2567
+  Registration Date: 12/12/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Roborough Community Property Association Limited
+  Registration Number: 4866
+  Registration Date: 11/01/2018
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Rochdale Boroughwide Housing Limited
+  Registration Number: 4607
+  Registration Date: 12/03/2012
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Rockdale Housing Association Limited
+  Registration Number: LH0869
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Rockingham Forest Housing Association Limited
+  Registration Number: L4009
+  Registration Date: 09/03/1993
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Rogate and Terwick Housing Association Limited
+  Registration Number: L0124
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Roger’s Almshouses
+  Registration Number: A0746
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Rooftop Housing Association Limited
+  Registration Number: LH4050
+  Registration Date: 20/09/1994
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Rooftop Housing Group Limited
+  Registration Number: L4404
+  Registration Date: 13/11/2003
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Rosebery Housing Association Limited
+  Registration Number: LH4026
+  Registration Date: 14/12/1993
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Rosemary Simmons Memorial Housing Association Limited
+  Registration Number: LH1026
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Rosewood Housing Limited
+  Registration Number: 5055
+  Registration Date: 02/08/2018
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Ross Walk Housing Co-operative Limited
+  Registration Number: C2977
+  Registration Date: 10/03/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Rossendale Borough Council
+  Registration Number: 30UM
+  Registration Date: 17/02/2011
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Rotary House For The Deaf Limited
+  Registration Number: LH1658
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Rotherham Metropolitan Borough Council
+  Registration Number: 00CF
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Rotherhithe Waterside Limited
+  Registration Number: H3731
+  Registration Date: 11/05/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Rowland Hill and Vaughan Almshouse Charity
+  Registration Number: A3552
+  Registration Date: 21/01/1985
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Royal Air Forces Association Housing Limited
+  Registration Number: L1508
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Royal Borough of Kensington and Chelsea
+  Registration Number: 00AW
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Royal Borough of Kingston Upon Thames
+  Registration Number: 00AX
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Rugby Borough Council
+  Registration Number: 44UD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Runnymede Borough Council
+  Registration Number: 43UG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Rusland Road Housing Co-operative Limited
+  Registration Number: C3693
+  Registration Date: 08/09/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Ryedale District Council
+  Registration Number: 36UF
+  Registration Date: 14/01/2013
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Rykneld Homes Limited
+  Registration Number: 4608
+  Registration Date: 06/06/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Sackville College
+  Registration Number: A0809
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Sadeh Lok Limited
+  Registration Number: L3807
+  Registration Date: 19/01/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Safer Places
+  Registration Number: 4761
+  Registration Date: 04/04/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Saffron Housing Trust Limited
+  Registration Number: LH4412
+  Registration Date: 24/02/2004
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sage Housing Limited
+  Registration Number: 4636
+  Registration Date: 13/12/2010
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Sage Rented Limited
+  Registration Number: 5083
+  Registration Date: 05/12/2019
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Sage Shared Ownership Limited
+  Registration Number: 5082
+  Registration Date: 05/12/2019
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Salford City Council
+  Registration Number: 00BR
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Salisbury City Almshouse and Welfare Charities
+  Registration Number: A0192
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Salix Homes Limited
+  Registration Number: 4609
+  Registration Date: 05/02/2015
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Salvation Army Housing Association
+  Registration Number: LH2429
+  Registration Date: 11/07/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sambourne Trust
+  Registration Number: A3183
+  Registration Date: 08/06/1981
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Samuel Lewis Foundation
+  Registration Number: LH0113
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Sanctuary Affordable Housing Limited
+  Registration Number: 4684
+  Registration Date: 01/12/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sanctuary Housing Association
+  Registration Number: L0247
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sandbach Almshouse Charity
+  Registration Number: A2806
+  Registration Date: 23/04/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Sandbourne Housing Association
+  Registration Number: LH0418
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sandwell Homeless and Resettlement Project Limited
+  Registration Number: 5054
+  Registration Date: 19/07/2018
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Sandwell Metropolitan Borough Council
+  Registration Number: 00CS
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Sapphire Independent Housing Limited
+  Registration Number: H1313
+  Registration Date: 26/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Saxon Weald
+  Registration Number: L4299
+  Registration Date: 17/11/2000
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Seagull Housing Co-operative Limited
+  Registration Number: C3097
+  Registration Date: 27/10/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Second Chance Housing Ltd
+  Registration Number: 4721
+  Registration Date: 21/06/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Sedgemoor District Council
+  Registration Number: 40UC
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Selby District Council
+  Registration Number: 36UH
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Selwood Housing Society Limited
+  Registration Number: LH4097
+  Registration Date: 10/10/1996
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Senacre Housing Co-operative Limited
+  Registration Number: C3518
+  Registration Date: 29/10/1984
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sensible Housing Co-operative Limited
+  Registration Number: C3472
+  Registration Date: 12/03/1984
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Settle Group
+  Registration Number: L4370
+  Registration Date: 13/02/2003
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Seven Dials Housing Co-operative Limited
+  Registration Number: C2580
+  Registration Date: 12/12/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Severn Almshouses Trust
+  Registration Number: A1048
+  Registration Date: 22/12/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Severnside Housing
+  Registration Number: LH4325
+  Registration Date: 18/09/2001
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Seymour Housing Co-operative Limited
+  Registration Number: C2318
+  Registration Date: 14/03/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Seymour Street Homes Limited
+  Registration Number: 4848
+  Registration Date: 04/04/2017
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Shahjalal Housing Co-operative Limited
+  Registration Number: C2824
+  Registration Date: 04/06/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: SHAL Housing Limited
+  Registration Number: LH4035
+  Registration Date: 15/03/1994
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Shanly Partnership Homes Limited
+  Registration Number: 4698
+  Registration Date: 29/03/2012
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Shearwood Housing Co-operative Limited
+  Registration Number: C3236
+  Registration Date: 26/10/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sheffield City Council
+  Registration Number: 00CG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Shepherds Bush Housing Association Limited
+  Registration Number: LH0050
+  Registration Date: 16/04/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Shepton Mallet United Charities
+  Registration Number: A0482
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Sherborne Close Housing Society Limited
+  Registration Number: L0849
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sherburn House Charity
+  Registration Number: A3494
+  Registration Date: 18/06/1984
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Shian Housing Association Limited
+  Registration Number: LH3883
+  Registration Date: 04/12/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Shorefields Co-operative Limited
+  Registration Number: C3411
+  Registration Date: 15/05/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Shorncliffe Housing Co-operative Limited
+  Registration Number: C4103
+  Registration Date: 28/05/1996
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Shrewsbury Drapers Company Charity
+  Registration Number: 4809
+  Registration Date: 23/02/2015
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Shropshire Association for Supported Housing Limited
+  Registration Number: H0134
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Shropshire Council
+  Registration Number: 00GG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Shropshire Rural Housing Association Limited
+  Registration Number: L1505
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sidcot Friends Housing Society Limited
+  Registration Number: H0299
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Silva Homes Limited
+  Registration Number: L4513
+  Registration Date: 22/01/2008
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sir E D Walker Homes
+  Registration Number: A0565
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Sir Job Charlton’s Hospital Charity
+  Registration Number: A2408
+  Registration Date: 13/06/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Sir Josiah Mason’s Almshouse Charity
+  Registration Number: A0629
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Sir Oswald Stoll Foundation
+  Registration Number: A3418
+  Registration Date: 20/06/1983
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Sir Robert Coke’s Almshouses
+  Registration Number: 4812
+  Registration Date: 05/03/2015
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Sir Robert Geffery’s Almshouse Trust
+  Registration Number: A2071
+  Registration Date: 30/07/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Sir William Turner’s Hospital
+  Registration Number: A4298
+  Registration Date: 15/11/2000
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Siward James and Arkwright Trust Charity
+  Registration Number: A2566
+  Registration Date: 12/12/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Six Town Housing Limited
+  Registration Number: 4612
+  Registration Date: 29/03/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Sloswicke’s Almshouse Charity
+  Registration Number: A2547
+  Registration Date: 14/11/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Slough Borough Council
+  Registration Number: 00MD
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Small Heath Park Housing Co-operative Limited
+  Registration Number: C2533
+  Registration Date: 14/11/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Smart and Humble Homes
+  Registration Number: A3326
+  Registration Date: 13/12/1982
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Soha Housing Limited
+  Registration Number: L4130
+  Registration Date: 21/05/1997
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Soho Housing Association Limited
+  Registration Number: LH1321
+  Registration Date: 26/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Solihull Care Housing Association Limited
+  Registration Number: L4191
+  Registration Date: 10/09/1998
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Solihull Metropolitan Borough Council
+  Registration Number: 00CT
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Solo Housing (East Anglia) Limited
+  Registration Number: 4696
+  Registration Date: 05/03/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Solon South West Housing Association Limited
+  Registration Number: L0125
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Somerset West and Taunton Council
+  Registration Number: 5067
+  Registration Date: 01/04/2019
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Somewhere Co-operative Housing Association Limited
+  Registration Number: C3027
+  Registration Date: 09/06/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: South Cambridgeshire District Council
+  Registration Number: 12UG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: South Camden Housing Co-operative Limited
+  Registration Number: C3275
+  Registration Date: 26/04/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: South Cheshire Housing Society Limited
+  Registration Number: L2034
+  Registration Date: 12/07/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: South Derbyshire District Council
+  Registration Number: 17UK
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: South Devon Rural Housing Association Limited
+  Registration Number: LH0920
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: South Hams District Council
+  Registration Number: 5078
+  Registration Date: 17/09/2019
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: South Holland District Council
+  Registration Number: 32UF
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: South Kesteven District Council
+  Registration Number: 32UG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: South Lakeland District Council
+  Registration Number: 16UG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: South Lakes Housing
+  Registration Number: 4686
+  Registration Date: 12/01/2012
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: South Liverpool Homes Limited
+  Registration Number: L4230
+  Registration Date: 14/09/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: South Mildmay Tenants Co-operative Limited
+  Registration Number: C2612
+  Registration Date: 08/08/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: South Northants Homes Limited
+  Registration Number: L4519
+  Registration Date: 26/02/2008
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: South Ribble Borough Council
+  Registration Number: 5085
+  Registration Date: 11/02/2020
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: South Road Housing Co-operative Limited
+  Registration Number: C3178
+  Registration Date: 23/07/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: South Staffordshire Housing Association Limited
+  Registration Number: LH4121
+  Registration Date: 06/03/1997
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: South Tyneside Council
+  Registration Number: 00CL
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: South Tyneside Housing Ventures Trust Limited
+  Registration Number: 4786
+  Registration Date: 27/02/2014
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: South Western Housing Society Limited
+  Registration Number: L2424
+  Registration Date: 09/07/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: South Yorkshire Housing Association Limited
+  Registration Number: L0078
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Southampton City Council
+  Registration Number: 00MS
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Southdene Housing Co-operative Limited
+  Registration Number: C3572
+  Registration Date: 17/06/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Southdown Housing Association Limited
+  Registration Number: L1829
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Southend on Sea Borough Council
+  Registration Number: 00KF
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Southend-on-Sea Young Men’s Christian Association
+  Registration Number: 4853
+  Registration Date: 13/07/2017
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Southern Crescent Co-operative Limited
+  Registration Number: C3302
+  Registration Date: 12/07/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Southern Home Ownership Limited
+  Registration Number: LH1662
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Southern Housing Group Limited
+  Registration Number: L4628
+  Registration Date: 01/10/2010
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Southlands Almshouse Charity
+  Registration Number: A2130
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Southsea Self Help Housing Limited
+  Registration Number: C3555
+  Registration Date: 11/03/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Southward Housing Co-operative Limited
+  Registration Number: C2581
+  Registration Date: 12/12/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Southwark Council
+  Registration Number: 00BE
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Southway Housing Trust (Manchester) Limited
+  Registration Number: L4507
+  Registration Date: 13/11/2007
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sovereign Housing Association Limited
+  Registration Number: 4837
+  Registration Date: 11/11/2016
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sovereign Living Limited
+  Registration Number: L3933
+  Registration Date: 03/12/1990
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Spelthorne Borough Council
+  Registration Number: 5091
+  Registration Date: 16/03/2020
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Spire Homes (LG) Limited
+  Registration Number: LH4302
+  Registration Date: 13/02/2001
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Spitalfields Housing Association Limited
+  Registration Number: C3022
+  Registration Date: 09/06/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Spotland and Falinge Housing Association Limited
+  Registration Number: SL3270
+  Registration Date: 01/03/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Springboard Two Housing Association Limited
+  Registration Number: SL3365
+  Registration Date: 24/01/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Springwood Housing Co-operative Limited
+  Registration Number: C3695
+  Registration Date: 08/09/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Square Building Trust Limited
+  Registration Number: L1218
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: St Albans City and District Council
+  Registration Number: 26UG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: St Andrew Housing Co-operative Limited
+  Registration Number: C2531
+  Registration Date: 24/04/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: St Andrews Community Housing Association Ltd
+  Registration Number: L4546
+  Registration Date: 10/12/2009
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: St Annes Community Services
+  Registration Number: H3158
+  Registration Date: 27/04/1981
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: St Anne’s Hostel
+  Registration Number: H4276
+  Registration Date: 08/06/2000
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: St Basil’s
+  Registration Number: H3994
+  Registration Date: 22/09/1992
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: St Christopher’s Fellowship
+  Registration Number: LH1832
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: St George’s Church Housing Co-operative Limited
+  Registration Number: C4054
+  Registration Date: 01/11/1994
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: St Johns Homes
+  Registration Number: A2840
+  Registration Date: 16/07/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: St Joseph’s Almshouses
+  Registration Number: A3456
+  Registration Date: 05/12/1983
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: St Leonards Hospital
+  Registration Number: A1325
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: St Luke’s Housing Society Limited
+  Registration Number: L1824
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: St Martin of Tours Housing Association Limited
+  Registration Number: H3021
+  Registration Date: 09/06/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: St Mungo Community Housing Association
+  Registration Number: LH0279
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: St Peter’s Saltley Housing Association Limited
+  Registration Number: L3519
+  Registration Date: 29/10/1984
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: St Richard of Chichester Christian Care Association Ltd
+  Registration Number: 4738
+  Registration Date: 19/10/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: St. Arthur Homes Limited
+  Registration Number: 4753
+  Registration Date: 22/02/2013
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Stafford & Rural Homes
+  Registration Number: L4458
+  Registration Date: 24/01/2006
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Stanley & Brocklehurst Almshouses
+  Registration Number: A3911
+  Registration Date: 19/03/1990
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Starley Housing Co-operative Limited
+  Registration Number: C2731
+  Registration Date: 29/09/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Stephen Hutchen’s Charity Trust
+  Registration Number: A4024
+  Registration Date: 14/12/1993
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Sterling Housing Association Limited
+  Registration Number: 4665
+  Registration Date: 18/07/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Steve Biko Housing Association Limited
+  Registration Number: L3711
+  Registration Date: 02/02/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Stevenage Borough Council
+  Registration Number: 26UH
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Stevenage Haven
+  Registration Number: 4815
+  Registration Date: 25/03/2015
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Stevens Almshouses Charity
+  Registration Number: A0532
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Stewart’s and Budgen’s Almshouses
+  Registration Number: A3722
+  Registration Date: 23/03/1987
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Stockport Homes Limited
+  Registration Number: 4619
+  Registration Date: 08/02/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Stockport Metropolitan Borough Council
+  Registration Number: 00BS
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Stoke on Trent & North Staffordshire YMCA Foyer
+  Registration Number: H4426
+  Registration Date: 13/07/2004
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Stoke on Trent City Council
+  Registration Number: 00GL
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Stoke-on-Trent Housing Society Limited
+  Registration Number: L0021
+  Registration Date: 25/03/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Stonewater (2) Limited
+  Registration Number: L0173
+  Registration Date: 23/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Stonewater (3) Limited
+  Registration Number: L0288
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Stonewater (4) Limited
+  Registration Number: LH4027
+  Registration Date: 25/01/1994
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Stonewater (5) Limited
+  Registration Number: 4717
+  Registration Date: 07/06/2012
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Stonewater Limited
+  Registration Number: L1556
+  Registration Date: 12/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Stratford-on-Avon District Council
+  Registration Number: 5109
+  Registration Date: 22/10/2020
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Stroud District Council
+  Registration Number: 23UF
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Stroud Green Housing Co-operative Limited
+  Registration Number: C2436
+  Registration Date: 11/07/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sturts Community Trust
+  Registration Number: 5089
+  Registration Date: 05/03/2020
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Summerhill Housing Co-operative (Newcastle) Ltd
+  Registration Number: C3157
+  Registration Date: 27/04/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sunderland City Council
+  Registration Number: 5080
+  Registration Date: 26/11/2019
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Sunderland Riverside Housing Co-operative Limited
+  Registration Number: C3348
+  Registration Date: 03/11/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sunny Vale Supported Accommodation Ltd
+  Registration Number: 4749
+  Registration Date: 07/02/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Sunset Home Almshouses
+  Registration Number: A4272
+  Registration Date: 21/03/2000
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Sussex Housing & Care
+  Registration Number: LH0079
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sussex Overseas Housing Society Limited
+  Registration Number: LH1833
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sustain (UK) Ltd
+  Registration Number: 4687
+  Registration Date: 12/01/2012
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Sutton Bonington & Normanton Social Services Association Limited
+  Registration Number: L0469
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sutton Housing Society Limited
+  Registration Number: L0721
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Sutton Turner Houses
+  Registration Number: A3759
+  Registration Date: 07/12/1987
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Swan Housing Association Limited
+  Registration Number: L4145
+  Registration Date: 27/11/1997
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Swan Lane Housing Co-operative Limited
+  Registration Number: C3738
+  Registration Date: 22/06/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Swift Homes Limited
+  Registration Number: 4864
+  Registration Date: 05/12/2017
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Swindon Borough Council
+  Registration Number: 00HX
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Sybil Carthew Trust
+  Registration Number: A2704
+  Registration Date: 28/06/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Sydenham Housing Co-operative Limited
+  Registration Number: C3174
+  Registration Date: 08/06/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Synergy Housing Limited
+  Registration Number: 4680
+  Registration Date: 07/11/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Tally-Ho Housing Co-operative Limited
+  Registration Number: C2181
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Tamar Housing Society Limited
+  Registration Number: L2209
+  Registration Date: 13/12/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Tamil Community Housing Association Limited
+  Registration Number: L4376
+  Registration Date: 20/03/2003
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Tamworth Borough Council
+  Registration Number: 41UK
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Tamworth Cornerstone Housing Association Limited
+  Registration Number: 4659
+  Registration Date: 25/05/2011
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Tandridge District Council
+  Registration Number: 43UK
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Tangram Housing Co-operative Limited
+  Registration Number: C3001
+  Registration Date: 28/04/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Target Housing Limited
+  Registration Number: 4679
+  Registration Date: 03/11/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Taunton Heritage Trust
+  Registration Number: 5059
+  Registration Date: 12/10/2018
+  Designation: Non-Profit
+  Corporate Form: CIO-Charitable Incorporated Organisation
+-
+  Organisation Name: TBG Open Door Limited
+  Registration Number: 4843
+  Registration Date: 07/03/2017
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: TCUK Homes Limited
+  Registration Number: 4756
+  Registration Date: 07/03/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Teachers’ Housing Association Limited
+  Registration Number: LH0426
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Teesdale Housing Association Limited
+  Registration Number: L4469
+  Registration Date: 23/05/2006
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Teign Housing
+  Registration Number: LH4403
+  Registration Date: 13/11/2003
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Teignbridge District Council
+  Registration Number: 18UH
+  Registration Date: 22/08/2012
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Telford & Wrekin Council
+  Registration Number: 5102
+  Registration Date: 14/09/2020
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Tendring District Council
+  Registration Number: 22UN
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Tewkesbury Almshouse Trust
+  Registration Number: A3602
+  Registration Date: 16/09/1985
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Thame and District Housing Association Limited
+  Registration Number: L1537
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Thames Ditton Homes Limited
+  Registration Number: L0159
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Thames Valley Charitable Housing Association Limited
+  Registration Number: LH3702
+  Registration Date: 01/12/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Thames Valley Housing Association Limited
+  Registration Number: L0514
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Thanet District Council
+  Registration Number: 29UN
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: The Abbeyfield (Berkhamsted & Hemel Hempstead) Society Limited
+  Registration Number: H1167
+  Registration Date: 12/01/1976
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield (Chelsea & Fulham) Society Limited
+  Registration Number: H2228
+  Registration Date: 13/12/1976
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield (Christ Church) Society Limited
+  Registration Number: H2471
+  Registration Date: 12/09/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield (Colyton) Society Limited
+  Registration Number: H2776
+  Registration Date: 29/01/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield (Darlington) Society Limited
+  Registration Number: H0228
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield (Lyme Regis & District) Society Ltd
+  Registration Number: H2698
+  Registration Date: 28/06/1978
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield (Maidenhead) Society Limited
+  Registration Number: H0062
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield (Norwich) Society Limited
+  Registration Number: H1471
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield (Oxford) Society Limited
+  Registration Number: H2851
+  Registration Date: 16/07/1979
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield (Ripon and District) Society Ltd
+  Registration Number: H0229
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield (Streatham) Society Limited
+  Registration Number: H3480
+  Registration Date: 12/03/1984
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield (Wells) Society Limited
+  Registration Number: H2473
+  Registration Date: 12/09/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield (Weymouth) Society Limited
+  Registration Number: H0068
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Alresford and District Society Ltd
+  Registration Number: H3569
+  Registration Date: 22/04/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Barrow-in- Furness Society Limited
+  Registration Number: H0481
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Basildon Society Limited
+  Registration Number: H0552
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Berwick Society Limited
+  Registration Number: H2374
+  Registration Date: 09/05/1977
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Billericay Society Limited
+  Registration Number: H1607
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Bishop’s Castle & District Society Limited
+  Registration Number: H4156
+  Registration Date: 20/01/1998
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Blackmore Vale Society Limited
+  Registration Number: H2321
+  Registration Date: 14/03/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Bradford-on-Avon Society Limited
+  Registration Number: H2960
+  Registration Date: 28/01/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Buckland Monachorum Society Limited
+  Registration Number: H1335
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Burnham and Highbridge Society Ltd
+  Registration Number: H0001
+  Registration Date: 20/03/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Burnley Society Limited
+  Registration Number: H2715
+  Registration Date: 10/08/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Bury Society Limited
+  Registration Number: H2475
+  Registration Date: 12/09/1977
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Camborne Society Limited
+  Registration Number: H0480
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Canvey Island Society Limited
+  Registration Number: H1362
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Chalfonts Society Limited
+  Registration Number: H1470
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Crowborough Society Limited
+  Registration Number: H2257
+  Registration Date: 17/01/1977
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Deben Extra Care Society Limited
+  Registration Number: H3148
+  Registration Date: 09/03/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Deptford Society Limited
+  Registration Number: H2905
+  Registration Date: 22/10/1979
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Dorcas Society Limited
+  Registration Number: H3824
+  Registration Date: 05/12/1988
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Dulwich Society Limited
+  Registration Number: H0129
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield East London Extra Care Society Limited
+  Registration Number: H3860
+  Registration Date: 15/05/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Ellesmere Port Society Limited
+  Registration Number: H3763
+  Registration Date: 07/12/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Fareham Society Limited
+  Registration Number: H0301
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Ferring Society Limited
+  Registration Number: H3162
+  Registration Date: 27/04/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Furness Extra Care Society Limited
+  Registration Number: H3955
+  Registration Date: 30/10/1991
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Gerrards Cross Society Limited
+  Registration Number: H1598
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Gloucestershire Society Limited
+  Registration Number: H2109
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Great Missenden & District Society
+  Registration Number: H0553
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Holsworthy Society Limited
+  Registration Number: H2961
+  Registration Date: 28/01/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Hoylake and West Kirby Society Ltd
+  Registration Number: H2854
+  Registration Date: 16/07/1979
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Kings Langley Society Limited
+  Registration Number: H3505
+  Registration Date: 23/07/1984
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Lancashire Extra Care Society Limited
+  Registration Number: H3873
+  Registration Date: 11/09/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Lancaster Society Limited
+  Registration Number: H3295
+  Registration Date: 07/06/1982
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield London Polish Society Limited
+  Registration Number: H3600
+  Registration Date: 16/09/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Loughborough Society Limited
+  Registration Number: H0595
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Newcastle-upon-Tyne Society Ltd
+  Registration Number: H0560
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield North Downs Society Limited
+  Registration Number: H3370
+  Registration Date: 24/01/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Orwell Extra Care Society Limited
+  Registration Number: H4115
+  Registration Date: 10/09/1996
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Oxenford Society Limited
+  Registration Number: H3680
+  Registration Date: 21/07/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Pirbright and District Society Ltd
+  Registration Number: H2934
+  Registration Date: 03/12/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Porlock Society Limited
+  Registration Number: H3230
+  Registration Date: 26/10/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Reading Society Limited
+  Registration Number: H2980
+  Registration Date: 10/03/1980
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Ribble Valley Society Limited
+  Registration Number: H3938
+  Registration Date: 22/01/1991
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Saltash Society Limited
+  Registration Number: H2295
+  Registration Date: 14/02/1977
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Sanderstead Society Limited
+  Registration Number: H0619
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Shanklin Society Limited
+  Registration Number: H2085
+  Registration Date: 30/07/1976
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Sidmouth Society Limited
+  Registration Number: H0335
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Society
+  Registration Number: H1046
+  Registration Date: 22/12/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Sodbury Vale Society Limited
+  Registration Number: H2791
+  Registration Date: 12/03/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield South Molton Society Limited
+  Registration Number: H3283
+  Registration Date: 26/04/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield South West Society Limited
+  Registration Number: H3383
+  Registration Date: 14/03/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Southend Society Limited
+  Registration Number: H0833
+  Registration Date: 10/05/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Tavistock Society Limited
+  Registration Number: H2755
+  Registration Date: 04/12/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Thirsk & Sowerby Society Limited
+  Registration Number: H3470
+  Registration Date: 23/01/1984
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Tiverton Society Limited
+  Registration Number: H0559
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Uxbridge Society Limited
+  Registration Number: H0548
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield West Herts Society Limited
+  Registration Number: H0213
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Whitehaven Society Limited
+  Registration Number: H0347
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield Widnes Society Limited
+  Registration Number: H4010
+  Registration Date: 09/03/1993
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Winchester Society Limited
+  Registration Number: H3405
+  Registration Date: 09/05/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Abbeyfield Worcester and Hereford Society Limited
+  Registration Number: H2907
+  Registration Date: 22/10/1979
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Abbeyfield York Society Limited
+  Registration Number: H2055
+  Registration Date: 30/07/1976
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Andover Charities
+  Registration Number: A0648
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Anerley Housing Co-operative Limited
+  Registration Number: C2577
+  Registration Date: 19/07/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Armstrong Home of Rest
+  Registration Number: L2618
+  Registration Date: 23/05/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Ash Homes
+  Registration Number: A2992
+  Registration Date: 28/04/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Baker’s Benevolent Society
+  Registration Number: A1072
+  Registration Date: 22/12/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Bampfylde Almshouse Charity
+  Registration Number: A2821
+  Registration Date: 04/06/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Barnes Fund
+  Registration Number: A2072
+  Registration Date: 30/07/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Berrow Cottage Homes
+  Registration Number: 5051
+  Registration Date: 19/06/2018
+  Designation: Non-Profit
+  Corporate Form: CIO-Charitable Incorporated Organisation
+-
+  Organisation Name: The Birch, Samson and Littleton United Charities
+  Registration Number: A4028
+  Registration Date: 25/01/1994
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Blackpool Fylde and Wyre Society for the Blind
+  Registration Number: L4005
+  Registration Date: 15/12/1992
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Blue House
+  Registration Number: 4859
+  Registration Date: 01/09/2017
+  Designation: Non-Profit
+  Corporate Form: CIO-Charitable Incorporated Organisation
+-
+  Organisation Name: The Buchanan Trust
+  Registration Number: 4874
+  Registration Date: 05/04/2018
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Butterfield Homes - Crosshills
+  Registration Number: A3163
+  Registration Date: 27/04/1981
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Cambridge Housing Society Limited
+  Registration Number: L0992
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Cambridgeshire Cottage Housing Society Limited
+  Registration Number: L0889
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Charity of Hannah Clarke for Almshouses
+  Registration Number: A4012
+  Registration Date: 09/03/1993
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Charity of Mrs Mabel Luke
+  Registration Number: 4840
+  Registration Date: 10/01/2017
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Charity of St Leonard’s Hospital
+  Registration Number: A2233
+  Registration Date: 13/12/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Charity of Thomas Fewson Eagles
+  Registration Number: A2836
+  Registration Date: 16/07/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Charlesworth Charity
+  Registration Number: A2986
+  Registration Date: 28/04/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Christian Union Almshouses
+  Registration Number: A0826
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Cinque Cottages
+  Registration Number: A3706
+  Registration Date: 01/12/1986
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The City of London Almshouses
+  Registration Number: A2266
+  Registration Date: 17/01/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Community Housing Group Limited
+  Registration Number: LH4264
+  Registration Date: 21/03/2000
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Cyril Wood Memorial Trust
+  Registration Number: L3500
+  Registration Date: 23/07/1984
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Drapers’ Almshouse Charity
+  Registration Number: A3612
+  Registration Date: 21/10/1985
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Duchess of Somerset’s Hospital
+  Registration Number: A3036
+  Registration Date: 14/07/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Edward Mayes Trust
+  Registration Number: 4767
+  Registration Date: 15/05/2013
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Exaireo Trust Ltd
+  Registration Number: 4838
+  Registration Date: 13/12/2016
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The ExtraCare Charitable Trust
+  Registration Number: 4706
+  Registration Date: 05/04/2012
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Faversham United Municipal Charities 2010
+  Registration Number: A1482
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Fellowship Houses Trust
+  Registration Number: L1821
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Feoffees of the Parish Lands of Highweek
+  Registration Number: A0542
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Field Lane Foundation
+  Registration Number: LH3047
+  Registration Date: 14/07/1980
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Finchley Charities
+  Registration Number: A0185
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Fishermen’s Hospital
+  Registration Number: A3486
+  Registration Date: 20/04/1984
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Flood Charity
+  Registration Number: A4037
+  Registration Date: 15/03/1994
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Fordham Memorial Homes
+  Registration Number: A1597
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Frances Darlington Charity
+  Registration Number: A4071
+  Registration Date: 14/03/1995
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Glendale Gateway Trust
+  Registration Number: 4683
+  Registration Date: 01/12/2011
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Gloucester Charities Trust
+  Registration Number: A0215
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Grange Centre for People with Disabilities
+  Registration Number: H3727
+  Registration Date: 11/05/1987
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Guinness Partnership Limited
+  Registration Number: 4729
+  Registration Date: 30/07/2012
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Hampton Parochial Charities
+  Registration Number: A1464
+  Registration Date: 08/03/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Harborne Parish Lands Charity
+  Registration Number: A2993
+  Registration Date: 28/04/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Harcourt Almshouse Charities
+  Registration Number: A3996
+  Registration Date: 22/09/1992
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Hartlepools War Memorial Homes & the Crosby Homes
+  Registration Number: A1055
+  Registration Date: 22/12/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Havebury Housing Partnership
+  Registration Number: LH4339
+  Registration Date: 06/06/2002
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Henry Gilder Drake Charity
+  Registration Number: A3946
+  Registration Date: 11/06/1991
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Honywood and Douglas Charity
+  Registration Number: A4001
+  Registration Date: 20/10/1992
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Hopkins & Sneyd Almshouse Charity
+  Registration Number: A2570
+  Registration Date: 12/12/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Hospital of Reverend William James
+  Registration Number: A2835
+  Registration Date: 16/07/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Hospital of St John & of St Anne in Okeham
+  Registration Number: A0611
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Hospital of St Thomas the Apostle in Doncaster
+  Registration Number: A1286
+  Registration Date: 26/01/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Hospital of the Holy Trinity Aylesford
+  Registration Number: A3564
+  Registration Date: 11/03/1985
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Hospital of William Parson (Stoke Hospital)
+  Registration Number: A2781
+  Registration Date: 29/01/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Hosyer-Foxe Charity
+  Registration Number: A3105
+  Registration Date: 08/12/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Housing Plus Group Limited
+  Registration Number: L4491
+  Registration Date: 22/05/2007
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Hunter Memorial Homes Trust
+  Registration Number: A2635
+  Registration Date: 24/04/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Huyton Community Co-op for the Elderly Ltd
+  Registration Number: C3531
+  Registration Date: 03/12/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Industrial Dwellings Society (1885) Limited
+  Registration Number: L0266
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The James Charities
+  Registration Number: A2150
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Jane Maddock Homes
+  Registration Number: A4407
+  Registration Date: 13/11/2003
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The John Henry Keene Memorial Homes
+  Registration Number: A3937
+  Registration Date: 22/01/1991
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Louisa Lilley Almshouses
+  Registration Number: A1329
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Lygon Almshouses
+  Registration Number: A0646
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Margaret Jane Ashley Almshouse Charity
+  Registration Number: A3997
+  Registration Date: 22/09/1992
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Merchant Taylors’ Boone’s Charity
+  Registration Number: A2246
+  Registration Date: 13/12/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Mile End Housing Co-operative Limited
+  Registration Number: C2513
+  Registration Date: 12/09/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Molyneux Almshouses
+  Registration Number: A4183
+  Registration Date: 09/06/1998
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Municipal Charities of Stratford-upon-Avon
+  Registration Number: A2785
+  Registration Date: 12/03/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The New College Of Cobham
+  Registration Number: A1347
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The New Cut Housing Co-operative Limited
+  Registration Number: C3641
+  Registration Date: 21/03/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The North Memorial Homes City of Leicester
+  Registration Number: L2793
+  Registration Date: 12/03/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Ogilvie Charities
+  Registration Number: A2819
+  Registration Date: 04/06/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Onslow Almshouses
+  Registration Number: A2892
+  Registration Date: 22/10/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Papworth Trust
+  Registration Number: LH1648
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Pathways Jubilee Charity
+  Registration Number: A1068
+  Registration Date: 22/12/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Peninsula Trust Limited
+  Registration Number: 5113
+  Registration Date: 05/11/2020
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Pioneer Housing and Community Group Limited
+  Registration Number: L4118
+  Registration Date: 22/01/1997
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Poynton-with-Worth Almshouse Charity
+  Registration Number: A3748
+  Registration Date: 21/09/1987
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Princes Park Housing Co-operative Limited
+  Registration Number: C2421
+  Registration Date: 07/07/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Reverend Rowland Hill Almshouse Charity
+  Registration Number: A0333
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Richmond Fellowship
+  Registration Number: H2025
+  Registration Date: 12/07/1976
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Riverside Group Limited
+  Registration Number: L4552
+  Registration Date: 31/03/2010
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Robert Salter Charity
+  Registration Number: A3590
+  Registration Date: 22/07/1985
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Saint Mary Magdalen’s Hospital
+  Registration Number: A4089
+  Registration Date: 25/01/1996
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Shen Place Almshouses
+  Registration Number: A3666
+  Registration Date: 16/06/1986
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Skinners’ Almshouse Charity
+  Registration Number: A2948
+  Registration Date: 28/01/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Society of Merchant Venturers’ Almshouse Charity
+  Registration Number: A3603
+  Registration Date: 16/09/1985
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Society of St James
+  Registration Number: LH4337
+  Registration Date: 20/03/2002
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The Sons of Divine Providence
+  Registration Number: LH4338
+  Registration Date: 20/03/2002
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: The St Michael’s Housing Trust
+  Registration Number: H1416
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Stuart Court Memorial Charity
+  Registration Number: A2803
+  Registration Date: 23/04/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Swaythling Housing Society Limited
+  Registration Number: L0689
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Teetotal Homes
+  Registration Number: A3667
+  Registration Date: 16/06/1986
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Villages Housing Association Limited
+  Registration Number: L3417
+  Registration Date: 25/07/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Walker Barstow Homes
+  Registration Number: A1276
+  Registration Date: 26/01/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The West Hackney Almshouse Charity
+  Registration Number: A2093
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The William Holmes Almshouses
+  Registration Number: A3388
+  Registration Date: 14/03/1983
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: The Winyates Co-operative Limited
+  Registration Number: C4382
+  Registration Date: 20/03/2003
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: The Wrekin Housing Group Limited
+  Registration Number: LH4220
+  Registration Date: 19/03/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Thirlmere Housing Co-operative Limited
+  Registration Number: C3190
+  Registration Date: 13/07/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Thirteen Housing Group Limited
+  Registration Number: L4522
+  Registration Date: 18/03/2008
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Thorner’s Homes
+  Registration Number: A0605
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Thorner’s Homes
+  Registration Number: 5111
+  Registration Date: 30/10/2020
+  Designation: Non-Profit
+  Corporate Form: CIO-Charitable Incorporated Organisation
+-
+  Organisation Name: Thorngate Churcher Trust
+  Registration Number: 4839
+  Registration Date: 20/12/2016
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Thornholme Housing Co-operative Limited
+  Registration Number: C3516
+  Registration Date: 29/10/1984
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Thornton Cottage Homes
+  Registration Number: A4417
+  Registration Date: 23/03/2004
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Thrale Almshouse and Relief in Need Charity
+  Registration Number: 4814
+  Registration Date: 25/03/2015
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Three Rivers District Council
+  Registration Number: 5107
+  Registration Date: 05/10/2020
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Thrive Homes Limited
+  Registration Number: L4520
+  Registration Date: 26/02/2008
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: THT and L&Q Community Limited
+  Registration Number: 5052
+  Registration Date: 05/07/2018
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Thurrock Council
+  Registration Number: 00KG
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Tiverton Almshouse Trust
+  Registration Number: A1070
+  Registration Date: 22/12/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Toddington United Almshouse Charity
+  Registration Number: A1063
+  Registration Date: 22/12/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Together Housing Association Limited
+  Registration Number: L4160
+  Registration Date: 17/02/1998
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Together Housing Group Limited
+  Registration Number: L4464
+  Registration Date: 21/03/2006
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Tonbridge and Malling Borough Council
+  Registration Number: 29UP
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Tonbridge United Charity
+  Registration Number: A2079
+  Registration Date: 30/07/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Tooting Bec Housing Co-operative Limited
+  Registration Number: C2613
+  Registration Date: 22/02/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Torus62 Limited
+  Registration Number: 5065
+  Registration Date: 16/01/2019
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Tower Hamlets Community Housing
+  Registration Number: L4260
+  Registration Date: 21/03/2000
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Town and Country Housing
+  Registration Number: L4251
+  Registration Date: 03/02/2000
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Townshend Close Housing Co-operative Limited
+  Registration Number: C3964
+  Registration Date: 21/01/1992
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: TPHA Limited
+  Registration Number: SL3442
+  Registration Date: 12/09/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Trafford Housing Trust Limited
+  Registration Number: L4440
+  Registration Date: 08/03/2005
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Transform Housing & Support
+  Registration Number: H2452
+  Registration Date: 11/07/1977
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Tregonwell Almshouse Trust
+  Registration Number: A0069
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Trent & Dove Housing Limited
+  Registration Number: L4311
+  Registration Date: 22/03/2001
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Triangle Housing Co-operative Limited
+  Registration Number: C2585
+  Registration Date: 12/12/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Trident Housing Association Limited
+  Registration Number: L0979
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Trinity Homes
+  Registration Number: A2455
+  Registration Date: 18/04/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Trinity Hospital at Clun
+  Registration Number: A4022
+  Registration Date: 14/12/1993
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Trinity Housing Association Limited
+  Registration Number: 4645
+  Registration Date: 07/03/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Tuntum Housing Association Limited
+  Registration Number: L3808
+  Registration Date: 05/12/1988
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Turning Point
+  Registration Number: H2509
+  Registration Date: 12/09/1977
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Twenty-Fifth Avenue Ltd
+  Registration Number: 4652
+  Registration Date: 07/04/2011
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Two Piers Housing Co-operative Limited
+  Registration Number: C2614
+  Registration Date: 01/12/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Two Rivers Housing
+  Registration Number: L4385
+  Registration Date: 20/03/2003
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Two Saints Limited
+  Registration Number: LH3904
+  Registration Date: 19/03/1990
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Tyne Housing Association Limited
+  Registration Number: LH4297
+  Registration Date: 15/11/2000
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Tyne Mariners’ Benevolent Institution
+  Registration Number: A3721
+  Registration Date: 23/03/1987
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: UCCLT Housing Ltd
+  Registration Number: 4861
+  Registration Date: 05/09/2017
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Uckfield & District Housing Association Limited
+  Registration Number: L0388
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: United Communities Limited
+  Registration Number: L3758
+  Registration Date: 07/12/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Unity Housing Association Limited
+  Registration Number: LH3737
+  Registration Date: 22/06/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Uttlesford District Council
+  Registration Number: 22UQ
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: V & F Homes Limited
+  Registration Number: 4867
+  Registration Date: 08/02/2018
+  Designation: Profit
+  Corporate Form: Company
+-
+  Organisation Name: Vale of Aylesbury Housing Trust Limited
+  Registration Number: L4473
+  Registration Date: 11/07/2006
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Vanbrugh and Tempest Almshouse Trust
+  Registration Number: A0627
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Vectis Housing Association Limited
+  Registration Number: L1005
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Veterans Aid
+  Registration Number: LH0674
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Victoria & Jubilee Homes
+  Registration Number: A3553
+  Registration Date: 21/01/1985
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Victoria Tenants Co-operative Limited
+  Registration Number: C2532
+  Registration Date: 14/11/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Victory Housing Trust
+  Registration Number: L4460
+  Registration Date: 24/01/2006
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Villages Community Housing Association Limited
+  Registration Number: LH4231
+  Registration Date: 14/09/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Vine Housing Co-operative Limited
+  Registration Number: C3499
+  Registration Date: 23/07/1984
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Viridian Housing
+  Registration Number: LH0172
+  Registration Date: 23/06/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Vivid Housing Limited
+  Registration Number: 4850
+  Registration Date: 04/05/2017
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: W14 Housing Co-operative Limited
+  Registration Number: C2696
+  Registration Date: 28/06/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Waddington Hospital
+  Registration Number: A3581
+  Registration Date: 17/06/1985
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Wakefield And District Housing Limited
+  Registration Number: L4441
+  Registration Date: 08/03/2005
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Wakefield Charities’ Homes
+  Registration Number: A2920
+  Registration Date: 03/12/1979
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Walsall Housing Group Limited
+  Registration Number: L4389
+  Registration Date: 21/03/2003
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Walterton and Elgin Community Homes Limited
+  Registration Number: L3939
+  Registration Date: 21/05/1991
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Waltham Forest Housing Association Limited
+  Registration Number: L0461
+  Registration Date: 28/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Walton-on-Thames Charity
+  Registration Number: A0157
+  Registration Date: 10/06/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Wandle Housing Association Limited
+  Registration Number: L0277
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Wargrave-on-Thames Housing Association Limited
+  Registration Number: L0053
+  Registration Date: 13/05/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Warrington Borough Council
+  Registration Number: 00EU
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Warrington Housing Association Limited
+  Registration Number: L0518
+  Registration Date: 12/09/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Warwick District Council
+  Registration Number: 44UF
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Warwick Housing Co-operative Limited
+  Registration Number: C4015
+  Registration Date: 20/07/1993
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Warwickshire Rural Housing Association Limited
+  Registration Number: L3881
+  Registration Date: 04/12/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Water Tower Housing Co-operative Limited
+  Registration Number: C2749
+  Registration Date: 31/01/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Watermans Housing Co-operative Limited
+  Registration Number: C3725
+  Registration Date: 20/11/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Waters Almshouses
+  Registration Number: A0208
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Watford Community Housing Trust
+  Registration Number: L4495
+  Registration Date: 24/07/2007
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Watmos Community Homes
+  Registration Number: L4383
+  Registration Date: 20/03/2003
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Waverley (Eighth) Co-operative Housing Association Limited
+  Registration Number: C2593
+  Registration Date: 13/02/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Waverley Borough Council
+  Registration Number: 43UL
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Wealden District Council
+  Registration Number: 21UH
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Wearmouth Housing Co-operative Limited
+  Registration Number: C3069
+  Registration Date: 15/09/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Weaver Vale Housing Trust Limited
+  Registration Number: L4341
+  Registration Date: 26/06/2002
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Weavers’ Almshouse Charities
+  Registration Number: A0261
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Webster Almshouse Trust
+  Registration Number: A0534
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Weller Streets Housing Co-operative Limited
+  Registration Number: C2692
+  Registration Date: 28/06/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Wellington Housing Co-operative Limited
+  Registration Number: C3789
+  Registration Date: 18/07/1988
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Wellington Mills Housing Co-operative Limited
+  Registration Number: C3278
+  Registration Date: 26/04/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Welwyn Garden City Housing Association Limited
+  Registration Number: L0668
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Welwyn Hatfield Borough Council
+  Registration Number: 26UL
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: West Berkshire District Council
+  Registration Number: 00MB
+  Registration Date: 07/12/2016
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: West Devon Borough Council
+  Registration Number: 5077
+  Registration Date: 17/09/2019
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: West End Housing Co-operative Limited
+  Registration Number: C2968
+  Registration Date: 11/03/1980
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: West Ham Non-Ecclesiastical Charity
+  Registration Number: A3311
+  Registration Date: 12/07/1982
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: West Hampstead Housing Co-operative Limited
+  Registration Number: C2418
+  Registration Date: 13/06/1977
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: West Herts Homes Limited
+  Registration Number: L1953
+  Registration Date: 14/06/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: West Kent Housing Association
+  Registration Number: LH3827
+  Registration Date: 30/01/1989
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: West Lancashire Borough Council
+  Registration Number: 30UP
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: West London Mission Housing Association Limited
+  Registration Number: LH3373
+  Registration Date: 14/03/1983
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: West London YMCA
+  Registration Number: H4128
+  Registration Date: 19/03/1997
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: West Mercia Homes Limited
+  Registration Number: 4746
+  Registration Date: 09/01/2013
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: West Norfolk Housing Company Ltd
+  Registration Number: 5057
+  Registration Date: 06/09/2018
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: West of England Friends Housing Society Limited
+  Registration Number: LH2186
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: West Suffolk Council
+  Registration Number: 5068
+  Registration Date: 01/04/2019
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Westfield Housing Association Limited
+  Registration Number: L0259
+  Registration Date: 15/07/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Westlea Housing Association Limited
+  Registration Number: LH4083
+  Registration Date: 07/11/1995
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Westlon Housing Association Limited
+  Registration Number: LH0424
+  Registration Date: 12/08/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Westminster Community Homes Limited
+  Registration Number: 4638
+  Registration Date: 16/12/2010
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Westmoreland Supported Housing Limited
+  Registration Number: 4772
+  Registration Date: 09/07/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Westree Road Housing Co-operative Limited
+  Registration Number: C4180
+  Registration Date: 09/06/1998
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Westvale Housing Co-operative Limited
+  Registration Number: C3723
+  Registration Date: 11/05/1987
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Westward Housing Group Limited
+  Registration Number: 4826
+  Registration Date: 01/06/2016
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Westway Housing Association Limited
+  Registration Number: LH3796
+  Registration Date: 05/09/1988
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Wey Valley Housing Association Limited
+  Registration Number: L1681
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Weybank Housing Co-operative Limited
+  Registration Number: C3337
+  Registration Date: 13/09/1982
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: WH Saunders Charity
+  Registration Number: A0544
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Whicher and Kifford Almshouses
+  Registration Number: A3011
+  Registration Date: 09/06/1980
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Whitby Merchant Seamen’s Hospital Houses
+  Registration Number: A4029
+  Registration Date: 25/01/1994
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: White Horse Housing Association Limited
+  Registration Number: L3559
+  Registration Date: 11/03/1985
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Whitefriars Housing Group Limited
+  Registration Number: LH4471
+  Registration Date: 21/03/2006
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Whitehead Almshouses
+  Registration Number: A3467
+  Registration Date: 23/01/1984
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Whitworth Housing Co-operative Limited
+  Registration Number: C3126
+  Registration Date: 26/01/1981
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Wickham Community Land Trust
+  Registration Number: 4692
+  Registration Date: 07/02/2012
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Wigan Council
+  Registration Number: 00BW
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Wilfrid East London Housing Co-operative Limited
+  Registration Number: C4225
+  Registration Date: 08/06/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Willesden Green Housing Co-operative Limited
+  Registration Number: C3394
+  Registration Date: 09/05/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: William Henry Hirst Memorial Homes
+  Registration Number: A1328
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: William Paul Housing Trust
+  Registration Number: A2643
+  Registration Date: 10/04/1978
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: William Russell Bequest
+  Registration Number: A0592
+  Registration Date: 14/10/1975
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Willow Park Housing Trust Limited
+  Registration Number: L4219
+  Registration Date: 19/03/1999
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Wiltshire Council
+  Registration Number: 00HY
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Winchester City Council
+  Registration Number: 24UP
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Winchester Working Men’s Housing Society Limited
+  Registration Number: L2732
+  Registration Date: 25/10/1978
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Windrush Alliance UK Community Interest Company
+  Registration Number: 4671
+  Registration Date: 04/08/2011
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Windsor and District Housing Association Limited
+  Registration Number: L4072
+  Registration Date: 27/04/1995
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Windsor Walk Housing Association Limited
+  Registration Number: L1656
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Winner Trading Limited
+  Registration Number: 4762
+  Registration Date: 15/04/2013
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: Winnocks and Kendalls Almshouse Charity
+  Registration Number: 4830
+  Registration Date: 03/10/2016
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Winsor Housing Co-operative Limited
+  Registration Number: C3701
+  Registration Date: 20/10/1986
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Wirral Methodist Housing Association Limited
+  Registration Number: L0848
+  Registration Date: 10/11/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Wirral Metropolitan Borough Council
+  Registration Number: 00CB
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Wisbech Charities
+  Registration Number: A2144
+  Registration Date: 11/10/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Wisden Housing Co-operative Limited
+  Registration Number: C2772
+  Registration Date: 29/01/1979
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Witham Housing Association Limited
+  Registration Number: L1000
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: WM Housing Group Limited
+  Registration Number: L4185
+  Registration Date: 10/09/1998
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Woborns Almshouse
+  Registration Number: A4330
+  Registration Date: 13/02/2002
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Woking Borough Council
+  Registration Number: 43UM
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Wokingham Borough Council
+  Registration Number: 00MF
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Wollaston and Pauncefort Almshouse Charity
+  Registration Number: A3527
+  Registration Date: 29/10/1984
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Wolverhampton City Council
+  Registration Number: 00CW
+  Registration Date: 01/04/2010
+  Designation: Local Authority
+  Corporate Form:
+-
+  Organisation Name: Women’s Pioneer Housing Limited
+  Registration Number: L1548
+  Registration Date: 24/06/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Woodlands Quaker Home for Elderly People
+  Registration Number: H1395
+  Registration Date: 09/02/1976
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Woodley Sandford and Charvil Charitable Trust
+  Registration Number: A2366
+  Registration Date: 18/04/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Woodside Housing Co-operative Limited
+  Registration Number: C3509
+  Registration Date: 10/09/1984
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Woolfardisworthy Sports and Community Hall
+  Registration Number: 5101
+  Registration Date: 03/09/2020
+  Designation: Non-Profit
+  Corporate Form: CIO-Charitable Incorporated Organisation
+-
+  Organisation Name: Worcester Municipal Charities CIO
+  Registration Number: 4855
+  Registration Date: 01/08/2017
+  Designation: Non-Profit
+  Corporate Form: CIO-Charitable Incorporated Organisation
+-
+  Organisation Name: Worcestershire YMCA Limited
+  Registration Number: LH3687
+  Registration Date: 08/09/1986
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Worthing Homes Limited
+  Registration Number: LH4208
+  Registration Date: 11/03/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Wrott and Hill Charity
+  Registration Number: A3246
+  Registration Date: 07/12/1981
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Wyedean Housing Association Limited
+  Registration Number: L1867
+  Registration Date: 10/05/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Wythenshawe Community Housing Group Limited
+  Registration Number: 4755
+  Registration Date: 07/03/2013
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Yardley Great Trust
+  Registration Number: A2247
+  Registration Date: 17/01/1977
+  Designation: Non-Profit
+  Corporate Form: Charity
+-
+  Organisation Name: Yarlington Housing Group
+  Registration Number: LH4200
+  Registration Date: 25/02/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: YMCA Bedfordshire
+  Registration Number: H3858
+  Registration Date: 15/05/1989
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: YMCA Black Country Group
+  Registration Number: L4550
+  Registration Date: 04/03/2010
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: YMCA Brunel Group
+  Registration Number: 4871
+  Registration Date: 08/03/2018
+  Designation: Non-Profit
+  Corporate Form: Company
+-
+  Organisation Name: YMCA Derbyshire
+  Registration Number: H4085
+  Registration Date: 05/12/1995
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: YMCA Downslink Group
+  Registration Number: 4644
+  Registration Date: 28/02/2011
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: YMCA East Surrey
+  Registration Number: 4854
+  Registration Date: 01/08/2017
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: YMCA Fairthorne Housing
+  Registration Number: 4875
+  Registration Date: 05/04/2018
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: YMCA Norfolk
+  Registration Number: H3868
+  Registration Date: 11/09/1989
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: YMCA North Tyneside
+  Registration Number: 4793
+  Registration Date: 03/07/2014
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: YMCA St Helens
+  Registration Number: LH3685
+  Registration Date: 21/07/1986
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: YMCA St Pauls Group
+  Registration Number: LH4078
+  Registration Date: 25/09/1995
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: YMCA Thames Gateway
+  Registration Number: L4547
+  Registration Date: 10/12/2009
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: YMCA Trinity Group
+  Registration Number: H4179
+  Registration Date: 09/06/1998
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: York Housing Association Limited
+  Registration Number: L1019
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Yorkshire Housing Limited
+  Registration Number: L4521
+  Registration Date: 01/04/2008
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Yorkshire Ladies Council (Hostels) Limited
+  Registration Number: LH1020
+  Registration Date: 08/12/1975
+  Designation: Non-Profit
+  Corporate Form: Charitable Company
+-
+  Organisation Name: Your Housing Group Limited
+  Registration Number: L4203
+  Registration Date: 25/02/1999
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Your Housing Limited
+  Registration Number: L1700
+  Registration Date: 12/04/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: ZAH Housing Co-operative Limited
+  Registration Number: C3376
+  Registration Date: 20/06/1983
+  Designation: Non-Profit
+  Corporate Form: Registered Society
+-
+  Organisation Name: Zebra Housing Association Limited
+  Registration Number: LH2018
+  Registration Date: 12/07/1976
+  Designation: Non-Profit
+  Corporate Form: Registered Society


### PR DESCRIPTION
## Changes in this PR

Create a Provider model to hold the information for Registered Housing providers.

Gov.uk publishes a list of registered providers [here](https://www.gov.uk/government/publications/current-registered-providers-of-social-housing/list-of-registered-providers-17-september-2020). We have scraped this information and added it to the database seeds.

All of the fields in the Provider model are mandatory, except for `Corporate form` when the `Designation` is Local Authority. 

This PR also introduces the `shoulda-matchers` gem
